### PR TITLE
fix: replaced bitnami NATS image with NATS native image

### DIFF
--- a/docker-compose.infrastructure.yaml
+++ b/docker-compose.infrastructure.yaml
@@ -24,5 +24,5 @@ services:
       - ./arango/migration/base/00-CREATE.js:/docker-entrypoint-initdb.d/00-CREATE.js
 
   nats:
-    image: docker.io/bitnami/nats:2
+    image: nats:2
     restart: always


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

Replaced bitnami NATS container image with NATS native container image

## Why are we doing this?

Broadcom/Bitnami pulled all their container images off DockerHub to move to a paid-for service.

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
