### PR TITLE
refactor(infra): parameterise repo branch across deploy scripts and bootstrap template

### DIFF
--- a/infra/aws/aws-deployment-instructions.md
+++ b/infra/aws/aws-deployment-instructions.md
@@ -1040,8 +1040,19 @@ It runs once at first boot and:
    `/home/ec2-user/.docker/` so the ec2-user account can pull images
 7. Writes `/home/ec2-user/.bootstrap-complete` marker
 
-**Template variable note:**  
-`${region}` is substituted by OpenTofu.  
+**Template variables:**
+
+| Variable | Source | Default | Purpose |
+|---|---|---|---|
+| `${region}` | `var.region` in `variables.tf` | `ap-south-1` | AWS region passed to `aws configure` |
+| `${repo_branch}` | `var.repo_branch` in `variables.tf` | `dev` | Git branch cloned at first boot |
+
+To deploy instances onto a different branch, set `repo_branch` in
+`terraform.tfvars` before running `tofu apply`:
+```hcl
+repo_branch = "my-feature-branch"
+```
+
 Bash variables in the template use `$${VAR}` (double dollar) which OpenTofu
 renders as `${VAR}` - standard bash parameter expansion in the output script.
 
@@ -1087,7 +1098,15 @@ Files created:
   passes the same rendered string to all three `module "server_*"` calls.
 
 [infra/aws/variables.tf](full-stack-docker-tazama/infra/aws/variables.tf) -
-only `key_name` is required; everything else has a default.
+only `key_name` is required; everything else has a sensible default.
+
+Key optional variables:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `repo_branch` | `dev` | Git branch cloned on EC2 instances at bootstrap. Override in `terraform.tfvars` to target a different branch for fresh deployments. |
+| `instance_type_a` / `_b` | `t3.xlarge` | EC2 size for Server A and B |
+| `instance_type_c` | `r5.2xlarge` | EC2 size for Server C (Ozone needs memory) |
 
 [infra/aws/terraform.tfvars.example](full-stack-docker-tazama/infra/aws/terraform.tfvars.example)
 - copy to `terraform.tfvars` (gitignored) and set at minimum `key_name = "tazama-aws"`.
@@ -2094,7 +2113,11 @@ cd scripts
 .\deploy-biar.ps1
 ```
 
-**Note:** New instances will clone the correct branch automatically via the updated `bootstrap.sh.tpl`. The branch-switch step in the deploy scripts is still present as a safety net but will be a no-op for freshly bootstrapped instances.
+**Note:** New instances clone the branch specified by `var.repo_branch` (default `dev`) via `bootstrap.sh.tpl`. The branch-switch step in the deploy scripts (`deploy-core.ps1`, `deploy-extensions.ps1`, `deploy-biar.ps1`) reads `$Script:RepoBranch` from `helpers.ps1` (also defaults to `dev`) and is a no-op for freshly bootstrapped instances but acts as a safety net if a server was provisioned against an older bootstrap.
+
+To switch the target branch across **all** scripts and the bootstrap template, change two values:
+1. `$Script:RepoBranch` in `infra/aws/scripts/helpers.ps1`
+2. `repo_branch` default (or `terraform.tfvars` override) in `infra/aws/variables.tf`
 
 ---
 

--- a/infra/aws/main.tf
+++ b/infra/aws/main.tf
@@ -124,7 +124,8 @@ data "aws_ami" "al2023" {
 
 locals {
   bootstrap = templatefile("${path.module}/templates/bootstrap.sh.tpl", {
-    region = var.region
+    region      = var.region
+    repo_branch = var.repo_branch
   })
 }
 

--- a/infra/aws/scripts/deploy-biar.ps1
+++ b/infra/aws/scripts/deploy-biar.ps1
@@ -51,7 +51,7 @@ Wait-Bootstrap -InstanceId $idC -ServerName 'Server C'
 
 # -- 1a. Ensure correct repo branch and pull latest ---------------------------
 Write-Host '[Server C] Ensuring correct repo branch and pulling latest...'
-Invoke-RemoteCommand -InstanceId $idC -Command "cd $Script:RemoteRepo && git fetch origin tazama/feat/mono-repo-phased-deployment && git checkout tazama/feat/mono-repo-phased-deployment && git pull origin tazama/feat/mono-repo-phased-deployment"
+Invoke-RemoteCommand -InstanceId $idC -Command "cd $Script:RemoteRepo && git fetch origin $Script:RepoBranch && git checkout $Script:RepoBranch && git reset --hard origin/$Script:RepoBranch"
 Write-Host '[Server C] Repo up to date.' -ForegroundColor Green
 
 # -- 2. Copy .env --------------------------------------------------------------

--- a/infra/aws/scripts/deploy-core.ps1
+++ b/infra/aws/scripts/deploy-core.ps1
@@ -44,7 +44,7 @@ Wait-Bootstrap -InstanceId $idA -ServerName 'Server A'
 
 # -- 2. Pull latest repo changes on Server A ----------------------------------
 Write-Host '[Server A] Pulling latest repo changes...'
-Invoke-RemoteCommand -InstanceId $idA -Command "cd $Script:RemoteRepo && git fetch origin tazama/feat/mono-repo-phased-deployment && git checkout tazama/feat/mono-repo-phased-deployment && git reset --hard origin/tazama/feat/mono-repo-phased-deployment"
+Invoke-RemoteCommand -InstanceId $idA -Command "cd $Script:RemoteRepo && git fetch origin $Script:RepoBranch && git checkout $Script:RepoBranch && git reset --hard origin/$Script:RepoBranch"
 Write-Host '[Server A] Repo up to date.' -ForegroundColor Green
 
 # -- 3. Copy .env files to Server A -------------------------------------------

--- a/infra/aws/scripts/deploy-extensions.ps1
+++ b/infra/aws/scripts/deploy-extensions.ps1
@@ -54,7 +54,7 @@ Copy-ToRemote -InstanceId $idA -LocalPath $localExtEnv -RemotePath "$Script:Remo
 # Pull latest so any changes to extensions compose files / env are picked up.
 Write-Host ''
 Write-Host '[Server A] Pulling latest repo...'
-Invoke-RemoteCommand -InstanceId $idA -Command "cd $Script:RemoteRepo && git fetch origin tazama/feat/mono-repo-phased-deployment && git checkout tazama/feat/mono-repo-phased-deployment && git reset --hard origin/tazama/feat/mono-repo-phased-deployment"
+Invoke-RemoteCommand -InstanceId $idA -Command "cd $Script:RemoteRepo && git fetch origin $Script:RepoBranch && git checkout $Script:RepoBranch && git reset --hard origin/$Script:RepoBranch"
 Write-Host '[Server A] Repo up to date.' -ForegroundColor Green
 
 Write-Host '[Server A] Adding DEMS + DEAPI to tazama-core...'
@@ -73,7 +73,7 @@ Wait-Bootstrap -InstanceId $idB -ServerName 'Server B'
 # Switch to the correct mono-repo branch and pull latest so all compose/config
 # changes are present.
 Write-Host '[Server B] Ensuring correct repo branch and pulling latest...'
-Invoke-RemoteCommand -InstanceId $idB -Command "cd $Script:RemoteRepo && git fetch origin tazama/feat/mono-repo-phased-deployment && git checkout tazama/feat/mono-repo-phased-deployment && git reset --hard origin/tazama/feat/mono-repo-phased-deployment"
+Invoke-RemoteCommand -InstanceId $idB -Command "cd $Script:RemoteRepo && git fetch origin $Script:RepoBranch && git checkout $Script:RepoBranch && git reset --hard origin/$Script:RepoBranch"
 Write-Host '[Server B] Repo up to date.' -ForegroundColor Green
 
 # -- 4. Server B: copy .env ---------------------------------------------------

--- a/infra/aws/scripts/helpers.ps1
+++ b/infra/aws/scripts/helpers.ps1
@@ -22,8 +22,9 @@ $ErrorActionPreference = 'Stop'
 $Script:AwsRegion  = 'ap-south-1'
 $Script:AwsProfile = 'tazama'
 $Script:KeyFile    = Join-Path $PSScriptRoot '..\tazama-aws.pem'
-$Script:RemoteRepo = '/home/ec2-user/full-stack-docker-tazama'
-$Script:RemoteUser = 'ec2-user'
+$Script:RemoteRepo   = '/home/ec2-user/full-stack-docker-tazama'
+$Script:RemoteUser   = 'ec2-user'
+$Script:RepoBranch   = 'dev'
 # Resolve aws.exe to its full path so OpenSSH can execute it in a ProxyCommand.
 # When OpenSSH spawns ProxyCommand it may not inherit PowerShell's PATH.
 $Script:AwsExe = (Get-Command aws -ErrorAction SilentlyContinue).Source

--- a/infra/aws/templates/bootstrap.sh.tpl
+++ b/infra/aws/templates/bootstrap.sh.tpl
@@ -13,7 +13,7 @@ exec > >(tee /var/log/tazama-bootstrap.log | logger -t tazama-bootstrap) 2>&1
 
 REGION="${region}"
 REPO_URL="https://github.com/tazama-lf/full-stack-docker-tazama.git"
-REPO_BRANCH="tazama/feat/mono-repo-phased-deployment"
+REPO_BRANCH="${repo_branch}"
 REPO_DIR="/home/ec2-user/full-stack-docker-tazama"
 EC2_USER="ec2-user"
 

--- a/infra/aws/variables.tf
+++ b/infra/aws/variables.tf
@@ -6,6 +6,12 @@ variable "prefix" {
   default     = "tazama"
 }
 
+variable "repo_branch" {
+  description = "Git branch cloned on EC2 instances at bootstrap"
+  type        = string
+  default     = "dev"
+}
+
 variable "region" {
   description = "AWS region to deploy into"
   type        = string


### PR DESCRIPTION
## Summary

Replaces all hardcoded branch references (`tazama/feat/mono-repo-phased-deployment`, then `dev`) with a single parameterised source of truth, so a future branch change requires editing **two files** instead of many.

## Changes

### PowerShell deploy scripts
- `helpers.ps1` — adds `$Script:RepoBranch = 'dev'` alongside the other script-scoped constants
- `deploy-core.ps1`, `deploy-extensions.ps1`, `deploy-biar.ps1` — replace hardcoded branch strings with `$Script:RepoBranch`

### OpenTofu IaC
- `variables.tf` — adds `variable "repo_branch"` (default `"dev"`)
- `main.tf` — threads `repo_branch = var.repo_branch` into the `bootstrap.sh.tpl` `templatefile()` call
- `templates/bootstrap.sh.tpl` — replaces the hardcoded `REPO_BRANCH="dev"` with the OpenTofu template variable `${repo_branch}`

### Docs
- `aws-deployment-instructions.md` — C.6 updated with a template variables table; C.8 updated with a key variables table; re-deployment note updated to describe the two-file change process

## How to change the branch in future

**Deploy scripts only** (existing servers):
```powershell
# helpers.ps1
$Script:RepoBranch = 'my-new-branch'
```

**Bootstrap + deploy scripts** (fresh `tofu apply`):
```hcl
# terraform.tfvars
repo_branch = "my-new-branch"
```
and update `$Script:RepoBranch` in `helpers.ps1` to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment scripts now dynamically reference a configurable Git branch instead of a hardcoded branch, enabling flexible deployment sourcing across all instances.

* **Documentation**
  * Updated AWS deployment documentation to document the new branch configuration variable, its default value, and instructions for customization via configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->