### PR TITLE
refactor(infra): parameterise repo branch + fix server C datalakehouse-api SG

### DIFF
--- a/biar/env/automation-orchestrator.env
+++ b/biar/env/automation-orchestrator.env
@@ -1,6 +1,9 @@
 AUTOMATION_ORCHESTRATOR_PORT=7619
 NUM_WORKERS=1
-S3A_ENDPOINT=http://${SERVER_C_HOST}:9878
+# Docker service name for Ozone S3G.  Must NOT use ${SERVER_C_HOST} here because
+# env_file: files are passed verbatim to containers — ${...} is not expanded.
+# Using the EC2 hostname also routes through the ENI where port 9878 is not in the SG.
+S3A_ENDPOINT=http://s3g:9878
 S3A_ACCESS_KEY=tazama
 S3A_SECRET_KEY=tazama
 WAREHOUSE_ROOT=/app/Tazama_Hudi_warehouse

--- a/biar/env/jupyterlab.env
+++ b/biar/env/jupyterlab.env
@@ -1,8 +1,11 @@
 # JupyterHub admin account (first user to sign up must match this name)
 JUPYTERHUB_ADMIN=admin
 
-# Hudi warehouse path inside the container
-WAREHOUSE_ROOT=/opt/Tazama_Hudi_warehouse
+# Hudi warehouse path inside the container.
+# Must match the container-side mount path defined in docker-compose.hub.biar.yaml:
+#   volumes: - ${TAZAMA_WAREHOUSE_HOST_PATH}:/opt/Tazama_Warehouse:ro
+# The previous value (/opt/Tazama_Hudi_warehouse) did not exist in the container.
+WAREHOUSE_ROOT=/opt/Tazama_Warehouse
 
 # Spark memory per user session
 SPARK_DRIVER_MEMORY=4g

--- a/biar/env/nifi.env
+++ b/biar/env/nifi.env
@@ -2,9 +2,14 @@ PB_CONTEXT_NAME=Parameters
 PB_NAME=pbucket
 PB_BUCKET=tazama
 PB_SENSITIVE_FALSE=false
-PB_HTTP_VALUE=http://${SERVER_C_HOST}:7619/checksubmit
+# NiFi parameter values — Docker service names must be used here, not SERVER_C_HOST.
+# All these services are in the same tazama-biar Docker project and reachable via
+# the Docker bridge network.  Using the external EC2 hostname routes traffic through
+# the EC2 ENI where the Security Group blocks ports 7619 and 9878 for self-referential
+# traffic.  Docker service-name DNS bypasses the ENI entirely.
+PB_HTTP_VALUE=http://automation-orchestrator:7619/checksubmit
 PB_HTTP_NAME=phttp
-PB_OZONE_ENDPOINT=http://${SERVER_C_HOST}:9878
+PB_OZONE_ENDPOINT=http://s3g:9878
 PB_OZONE_NAME=pozone
 
 IMPORT_NIFI_TEMPLATE=true

--- a/biar/env/unstructured-pipeline.env
+++ b/biar/env/unstructured-pipeline.env
@@ -5,9 +5,12 @@ FUNCTION_NAME=biar-processor
 COUCHDB_URL=http://simon:1234@${SERVER_B_HOST}:5984/cms-evidence
 
 # Processing Services
-TIKA_URL=http://${SERVER_C_HOST}:9998
-SOLR_URL=http://${SERVER_C_HOST}:8983/solr/biar_docs
-NIFI_URL=http://${SERVER_C_HOST}:8081/contentListener
+# Docker service names — tika, solr, and nifi are in the same tazama-biar project.
+# ${SERVER_C_HOST} must NOT be used here: env_file: values are not interpolated by
+# Docker Compose, and the EC2 SG blocks ports 9998, 8983, and 8081 for self-traffic.
+TIKA_URL=http://tika:9998
+SOLR_URL=http://solr:8983/solr/biar_docs
+NIFI_URL=http://nifi:8081/contentListener
 
 # Cron Configuration - runs every 30 seconds
 CRON_ENABLED=true

--- a/extensions/env/cms.env
+++ b/extensions/env/cms.env
@@ -79,6 +79,7 @@ COUCHDB_PASSWORD=1234
 # Visualization and Lakehouse
 VOILA_URL=http://tazama-cms-viola:8866
 GOLD_LAKEHOUSE_API_URL=http://${SERVER_C_HOST}:8282
+GOLD_LAKEHOUSE_TIMEOUT=120000
 
 # OpenSearch
 OPENSEARCH_NODE=http://opensearch-node1:9200

--- a/infra/aws/aws-deployment-instructions.md
+++ b/infra/aws/aws-deployment-instructions.md
@@ -73,19 +73,69 @@ full-stack-docker-tazama/
 Three private EC2 instances sit behind an Application Load Balancer. No instance has a public IP or any port 22 open. Operator SSH access uses the AWS EC2 Instance Connect Endpoint (EICE). All user traffic reaches services via the ALB.
 
 ```
-Local Workstation (Windows)
-│
-├── OpenTofu ───────────────────── provisions VPC, SGs, EC2, ALB, Route 53
-├── AWS CLI (EICE) ─────────────── SSH tunnel to private EC2 (no port 22 in any SG)
-└── deploy.ps1 ─────────────────── docker compose commands via EICE tunnel
+                        AWS Account - Tazama VPC (10.0.0.0/16)
+                        Private Subnet (10.0.1.0/24)
 
-Internet Users → ALB (public subnet, :80/:443)
-                   │
-         ┌─────────┼─────────┐
-         │         │         │
-    server-a   server-b  server-c
-    10.0.1.10  10.0.1.20  10.0.1.30
-    core       extensions  biar
+     ┌──────────────────────────┐
+     │  Local Workstation (you) │
+     │  Windows PC              │
+     │                          │
+     │  OpenTofu (IaC)          │──── provisions ────▶  VPC, subnets, SGs, EC2s, IAM, ALB
+     │  AWS CLI (EICE)          │──── SSH tunnel ────▶  EC2 instances (no port 22 open)
+     │  deploy.ps1              │──── docker compose ▶  via EICE SSH tunnel
+     └──────────────────────────┘
+
+     ┌──────────────────────────────────────────────────────────────┐
+     │  Application Load Balancer  (public subnet, ap-south-1)     │
+     │  HTTP — port-based routing (HTTPS + host-based: Phase E.3)  │
+     │  :5000  → Server A  tms-service                             │
+     │  :5100  → Server A  admin-service                           │
+     │  :3020  → Server A  auth-service                            │
+     │  :8080  → Server A  keycloak                                │
+     │  :5050  → Server A  pgAdmin (core)                          │
+     │  :6100  → Server A  hasura                                  │
+     │  :5173  → Server B  tcs-frontend                            │
+     │  :3010  → Server B  tcs-api                                 │
+     │  :5174  → Server B  trs-frontend                            │
+     │  :3005  → Server B  trs-api                                 │
+     │  :5175  → Server B  cms-frontend                            │
+     │  :3090  → Server B  cms-api                                 │
+     │  :5051  → Server B  pgAdmin (extensions)                    │
+     │  :8088  → Server C  nifi                                    │
+     │  :8000  → Server C  jupyterhub                              │
+     │  :7619  → Server C  auto-orchestrator                       │
+     │  :8282  → Server C  datalakehouse-api                       │
+     └──────────────────────────┬───────────────────────────────────┘
+                                │  VPC-internal routing (private IPs)
+              ┌─────────────────┼──────────────────┐
+              │                 │                  │
+    ┌─────────▼──────┐  ┌───────▼──────┐  ┌────────▼────────┐
+    │   server-a     │  │   server-b   │  │   server-c      │
+    │   tazama-core  │  │  extensions  │  │   biar          │
+    │   10.0.1.10    │  │  10.0.1.20   │  │   10.0.1.30     │
+    │                │  │              │  │                  │
+    │  tms     :5000 │  │ tcs    :5173 │  │ nifi       :8088│
+    │  admin   :5100 │  │ tcs-api:3010 │  │ jupyterhub :8000│
+    │  auth    :3020 │  │ trs    :5174 │  │ auto-orch  :7619│
+    │  keycloak:8080 │  │ trs-api:3005 │  │ dlh-api    :8282│
+    │  hasura  :6100 │  │ cms    :5175 │  │ solr       :8983│
+    │  pgadmin :5050 │  │ cms-api:3090 │  │ ozone-scm  :9876│
+    │  nats    :14222│  │ pgadmin:5051 │  │ ozone-s3g  :9878│
+    │  postgres:15432│  │ postgres:15433  │ ozone-recon:9888│
+    │  valkey  :16379│  │ opensrch:9200│  └────────┬────────┘
+    └────────────────┘  └──────┬───────┘           │
+           ▲  ▲  ▲             │    direct :8282    │
+           │  │  │             └────────────────────┘
+           │  │  │    (CMS backend → datalakehouse-api, bypasses ALB)
+           │  │  │
+           │  └── cross-server (NATS :14222, auth :3020, postgres :15432)
+           └───── cross-server (NiFi → postgres :15432)
+
+     ┌─────────────────────────────────────────────────────┐
+     │  EC2 Instance Connect Endpoint (EICE)               │
+     │  Private subnet — operator SSH access only          │
+     │  No port 22 in any Security Group                   │
+     └─────────────────────────────────────────────────────┘
 ```
 
 **Cross-server communication** uses private DNS (Route 53 private hosted zone `tazama.internal`):
@@ -960,20 +1010,68 @@ Files created:
 
 ### C.3 `modules/security-groups/`
 
-Four security groups:
+Four security groups. EC2 instances have **no internet-facing inbound rules** — all user traffic enters via the ALB, all operator SSH enters via EICE.
 
-| SG | Inbound from ALB | Inbound cross-server | SSH |
-|---|---|---|---|
-| ALB | 0.0.0.0/0: 80, 443 | - | - |
-| Server A | TMS 5000, DEAPI/DEMS/Auth 3001-3020, Admin 5100 | All TCP from `10.0.1.0/24` | EICE SG only |
-| Server B | TRS/TCS/CMS 3005-3090, frontends 5173-5175 | All TCP from `10.0.1.0/24` | EICE SG only |
-| Server C | NiFi 8088, JupyterHub 8000, Datalakehouse 8282 | 8282 from Server B SG (CMS direct call) | EICE SG only |
+> **ALB routing mode:** The ALB currently uses **port-based HTTP routing** — each service is reachable at `http://<alb-dns>:<port>`. Port 443 is pre-configured in the ALB SG for the future custom-domain HTTPS upgrade (Phase F), at which point all service ports except 443 can be removed from the ALB SG and traffic will route via SNI host header rules.
 
-The cross-server rule (`0-65535 from 10.0.1.0/24`) on Servers A and B covers all
-internal ports without maintaining a per-service list (NATS, PostgreSQL, Valkey,
-OpenSearch, Auth, etc.). Server C exposes the datalakehouse-api (port 8282) both
-via the ALB (for external/tunnelled access) and directly from Server B's SG (the
-CMS backend calls it directly, not via the ALB).
+#### sg-tazama-alb (Application Load Balancer)
+
+| Direction | Port(s) | Protocol | Source | Notes |
+|---|---|---|---|---|
+| Inbound | 443 | TCP | `0.0.0.0/0` | HTTPS — Phase F custom domain (pre-configured) |
+| Inbound | 5000 | TCP | `0.0.0.0/0` | TMS API |
+| Inbound | 5050–5051 | TCP | `0.0.0.0/0` | pgAdmin (Server A + B) |
+| Inbound | 5100 | TCP | `0.0.0.0/0` | Admin API |
+| Inbound | 3020 | TCP | `0.0.0.0/0` | Auth Service |
+| Inbound | 8080 | TCP | `0.0.0.0/0` | Keycloak |
+| Inbound | 6100 | TCP | `0.0.0.0/0` | Hasura |
+| Inbound | 3005–3090 | TCP | `0.0.0.0/0` | TRS / TCS / CMS backends |
+| Inbound | 5173–5175 | TCP | `0.0.0.0/0` | TCS / TRS / CMS frontends |
+| Inbound | 8088 | TCP | `0.0.0.0/0` | NiFi UI |
+| Outbound | All | All | `0.0.0.0/0` | Routing to EC2 target groups |
+
+> JupyterHub (:8000), Automation Orchestrator (:7619), and Datalakehouse API (:8282) have ALB target groups and listeners, but their ports are **not** open in the ALB SG — they are accessed via SSH tunnel (Phase E.1). Add them to the ALB SG when exposing them publicly.
+
+#### sg-tazama-server-a (Server A — tazama-core)
+
+| Direction | Port(s) | Protocol | Source | Notes |
+|---|---|---|---|---|
+| Inbound | 5000 | TCP | sg-tazama-alb | TMS API |
+| Inbound | 3001–3020 | TCP | sg-tazama-alb | DEAPI / DEMS / Auth Service range |
+| Inbound | 5100 | TCP | sg-tazama-alb | Admin API |
+| Inbound | 8080 | TCP | sg-tazama-alb | Keycloak |
+| Inbound | 5050–5051 | TCP | sg-tazama-alb | pgAdmin |
+| Inbound | 6100 | TCP | sg-tazama-alb | Hasura |
+| Inbound | 0–65535 | TCP | `10.0.1.0/24` | Cross-server (NATS :14222, PostgreSQL :15432, Valkey :16379, etc.) |
+| Inbound | 22 | TCP | sg-tazama-eice | SSH via EICE endpoint only |
+| Outbound | All | All | `0.0.0.0/0` | Image pulls, GitHub builds |
+
+#### sg-tazama-server-b (Server B — tazama-extensions)
+
+| Direction | Port(s) | Protocol | Source | Notes |
+|---|---|---|---|---|
+| Inbound | 3005–3090 | TCP | sg-tazama-alb | TRS / TCS / CMS backends |
+| Inbound | 5173–5175 | TCP | sg-tazama-alb | TCS / TRS / CMS frontends |
+| Inbound | 5051 | TCP | sg-tazama-alb | pgAdmin (extensions) |
+| Inbound | 0–65535 | TCP | `10.0.1.0/24` | Cross-server (OpenSearch :9200, PostgreSQL :15433, etc.) |
+| Inbound | 22 | TCP | sg-tazama-eice | SSH via EICE endpoint only |
+| Outbound | All | All | `0.0.0.0/0` | Image pulls, GitHub builds, Server A calls |
+
+#### sg-tazama-server-c (Server C — tazama-biar)
+
+| Direction | Port(s) | Protocol | Source | Notes |
+|---|---|---|---|---|
+| Inbound | 8088 | TCP | sg-tazama-alb | NiFi UI |
+| Inbound | 8000 | TCP | sg-tazama-alb | JupyterHub |
+| Inbound | 7619 | TCP | sg-tazama-alb | Automation Orchestrator |
+| Inbound | 8282 | TCP | sg-tazama-alb | Datalakehouse API (via ALB / tunnel) |
+| Inbound | 8282 | TCP | sg-tazama-server-b | Datalakehouse API (CMS backend direct call — bypasses ALB) |
+| Inbound | 22 | TCP | sg-tazama-eice | SSH via EICE endpoint only |
+| Outbound | All | All | `0.0.0.0/0` | Image pulls, calls to Server A + B |
+
+> Solr (:8983), Ozone SCM (:9876), Ozone S3G (:9878), and Ozone Recon (:9888) are **internal-only** — no SG inbound rules; accessed exclusively via the SSH tunnel (`tunnel-server-c.ps1`).
+
+> `sg-tazama-eice` is a small separate security group attached to the EICE VPC endpoint itself. It has no inbound rules; outbound allows TCP port 22 to `10.0.1.0/24` only. Each instance SG allows port 22 from this EICE SG only — not from the internet.
 
 Files created:
 - [infra/aws/modules/security-groups/variables.tf](full-stack-docker-tazama/infra/aws/modules/security-groups/variables.tf)

--- a/infra/aws/aws-deployment-instructions.md
+++ b/infra/aws/aws-deployment-instructions.md
@@ -967,12 +967,13 @@ Four security groups:
 | ALB | 0.0.0.0/0: 80, 443 | - | - |
 | Server A | TMS 5000, DEAPI/DEMS/Auth 3001-3020, Admin 5100 | All TCP from `10.0.1.0/24` | EICE SG only |
 | Server B | TRS/TCS/CMS 3005-3090, frontends 5173-5175 | All TCP from `10.0.1.0/24` | EICE SG only |
-| Server C | NiFi 8088, JupyterHub 8000 | (outbound only - Server C reaches A and B) | EICE SG only |
+| Server C | NiFi 8088, JupyterHub 8000, Datalakehouse 8282 | 8282 from Server B SG (CMS direct call) | EICE SG only |
 
 The cross-server rule (`0-65535 from 10.0.1.0/24`) on Servers A and B covers all
 internal ports without maintaining a per-service list (NATS, PostgreSQL, Valkey,
-OpenSearch, Auth, etc.). Server C only needs outbound since it is a consumer, not
-a provider; its egress `0.0.0.0/0` covers the NAT Gateway path to A and B.
+OpenSearch, Auth, etc.). Server C exposes the datalakehouse-api (port 8282) both
+via the ALB (for external/tunnelled access) and directly from Server B's SG (the
+CMS backend calls it directly, not via the ALB).
 
 Files created:
 - [infra/aws/modules/security-groups/variables.tf](full-stack-docker-tazama/infra/aws/modules/security-groups/variables.tf)
@@ -1980,7 +1981,27 @@ Invoke-RestMethod http://localhost:9200/_cluster/health | ConvertTo-Json
 - TRS frontend: http://localhost:5174
 - CMS frontend: http://localhost:5175
 
-**Cross-server connectivity:** TCS/TRS backends contact Server A for JWT validation (port 3020) and NATS relay (port 14222). If the frontend loads but API calls fail with 401/CORS, the `SERVER_A_HOST` overlay in `extensions/.env` was not applied — check the `env-extensions.tpl` template and re-run step 6 of `deploy-extensions.ps1` manually.
+**Cross-server connectivity (Server A):** TCS/TRS backends contact Server A for JWT validation (port 3020) and NATS relay (port 14222). If the frontend loads but API calls fail with 401/CORS, the `SERVER_A_HOST` overlay in `extensions/.env` was not applied — check the `env-extensions.tpl` template and re-run step 6 of `deploy-extensions.ps1` manually.
+
+**Cross-server connectivity (Server C — datalakehouse-api):** The CMS backend calls the datalakehouse-api on Server C directly (not via the ALB). Verify reachability from Server B:
+
+```powershell
+cd full-stack-docker-tazama\infra\aws
+. .\scripts\helpers.ps1
+$out = Get-TofuOutputs
+Invoke-RemoteCommand -InstanceId $out.ServerB_InstanceId -Command 'curl -s -o /dev/null -w "%{http_code} %{time_total}s" --max-time 10 http://biar.tazama.internal:8282/health'
+# Expected: 200 <time>s
+```
+
+If this returns `000` (connection failure), check two things:
+1. Server B's security group — it must be `tazama-server-b-sg`, **not** `tazama-server-a-sg`:
+   ```powershell
+   aws ec2 describe-instances --profile tazama --region ap-south-1 `
+     --instance-ids $out.ServerB_InstanceId `
+     --query "Reservations[0].Instances[0].SecurityGroups[*].GroupName" --output text
+   ```
+   If it shows `tazama-server-a-sg`, correct it: `aws ec2 modify-instance-attribute --profile tazama --region ap-south-1 --instance-id $out.ServerB_InstanceId --groups <server-b-sg-id>`
+2. Server C's SG must have an inbound rule for TCP 8282 from `tazama-server-b-sg`. A `tofu plan` will reveal and a `tofu apply` will correct any such drift.
 
 ---
 

--- a/infra/aws/end-to-end-service-flow.md
+++ b/infra/aws/end-to-end-service-flow.md
@@ -1,0 +1,551 @@
+# End-to-End Service Flow
+
+This document maps all inter-service communication across the three-server Tazama AWS
+deployment. Each section below covers a distinct data path or functional area.
+
+| Server | Hostname | Private IP | Stack |
+|---|---|---|---|
+| Server A | `core.tazama.internal` | `10.0.1.10` | tazama-core |
+| Server B | `extensions.tazama.internal` | `10.0.1.20` | tazama-extensions |
+| Server C | `biar.tazama.internal` | `10.0.1.30` | tazama-biar |
+
+---
+
+## 1. System Architecture Overview
+
+All three servers sit in a private subnet with no public IPs. User traffic enters via the
+Application Load Balancer (public subnet). Operator SSH access uses the EC2 Instance Connect
+Endpoint (EICE) — no port 22 exposed to the internet.
+
+```mermaid
+flowchart TD
+    Client(["Browser / API Client"])
+    SFTPc(["SFTP Client"])
+    Operator(["Operator / Workstation"])
+
+    subgraph ALBsg["ALB — public subnet"]
+        ALB["Application Load Balancer\nPort-based HTTP (Phase E)\nHTTPS :443 (Phase F)"]
+    end
+
+    subgraph SA["Server A — core.tazama.internal — 10.0.1.10"]
+        TMS["TMS :5000"]
+        Admin["Admin API :5100"]
+        Auth["Auth Service :3020"]
+        KC["Keycloak :8080"]
+        DEAPI["DEAPI :3001"]
+        DEMS["DEMS :3002"]
+        PGA["pgAdmin :5050"]
+        Hasura["Hasura :6100"]
+        NATS_A[("NATS\n:4222 / ext :14222")]
+        PG_A[("PostgreSQL\n:5432 / ext :15432")]
+        VK[("Valkey\n:6379 / ext :16379")]
+        PIPELINE["NATS Pipeline\nED → Rules → TP / EF / TADP"]
+        RS["Relay Services\nrsef · rstp · rstadp"]
+        Logging["Event Sidecar :15000\n+ Lumberjack"]
+    end
+
+    subgraph SB["Server B — extensions.tazama.internal — 10.0.1.20"]
+        TCSfe["TCS Frontend :5173"]
+        TCSbe["TCS Backend :3010"]
+        TRSfe["TRS Frontend :5174"]
+        TRSbe["TRS Backend :3005"]
+        CMSfe["CMS Frontend :5175"]
+        CMSbe["CMS Backend :3090"]
+        PGB["pgAdmin-ext :5051"]
+        PG_B[("PostgreSQL\n:5432 / ext :15433")]
+        OS[("OpenSearch :9200")]
+        CDB[("CouchDB :5984")]
+        FLW["Flowable :8080"]
+        SFTP["SFTP :12222"]
+    end
+
+    subgraph SC["Server C — biar.tazama.internal — 10.0.1.30"]
+        NiFi["NiFi :8088"]
+        AO["Automation Orchestrator :7619"]
+        DLH["Datalakehouse API :8282"]
+        JH["JupyterHub :8000"]
+        UP["Unstructured Pipeline"]
+        Tika["Tika :9998"]
+        Solr["Solr :8983 (tunnel only)"]
+        Ozone["Ozone Cluster\nS3G :9878 · SCM :9876\nOM :9862 · Recon :9888\nDatanodes ×3"]
+    end
+
+    EICE(["EICE Endpoint\n(no port 22 in any SG)"])
+
+    %% ── External ingress ──────────────────────────────────────────────────
+    Client -- "HTTP / HTTPS" --> ALB
+    SFTPc -- "SFTP :12222" --> SFTP
+    Operator -- "SSH via EICE" --> EICE
+    EICE -- ":22 (SG only)" --> SA
+    EICE -- ":22 (SG only)" --> SB
+    EICE -- ":22 (SG only)" --> SC
+
+    %% ── ALB → Server A ───────────────────────────────────────────────────
+    ALB -- ":5000" --> TMS
+    ALB -- ":5100" --> Admin
+    ALB -- ":3020" --> Auth
+    ALB -- ":8080" --> KC
+    ALB -- ":3001" --> DEAPI
+    ALB -- ":3002" --> DEMS
+    ALB -- ":5050" --> PGA
+    ALB -- ":6100" --> Hasura
+
+    %% ── ALB → Server B ───────────────────────────────────────────────────
+    ALB -- ":5173" --> TCSfe
+    ALB -- ":3010" --> TCSbe
+    ALB -- ":5174" --> TRSfe
+    ALB -- ":3005" --> TRSbe
+    ALB -- ":5175" --> CMSfe
+    ALB -- ":3090" --> CMSbe
+    ALB -- ":5051" --> PGB
+
+    %% ── ALB → Server C ───────────────────────────────────────────────────
+    ALB -- ":8088" --> NiFi
+    ALB -- ":8000" --> JH
+    ALB -- ":7619 (listener only)" --> AO
+    ALB -- ":8282 (listener only)" --> DLH
+
+    %% ── Server A internal ────────────────────────────────────────────────
+    TMS -- "event-director" --> NATS_A
+    NATS_A -- "pipeline" --> PIPELINE
+    PIPELINE -- "investigation-service" --> NATS_A
+    NATS_A -- "relay streams" --> RS
+    DEAPI --- NATS_A
+    DEMS --- NATS_A
+    PIPELINE --- PG_A
+    PIPELINE --- VK
+    TMS --- PG_A
+    TMS --- VK
+    DEAPI --- PG_A
+    DEAPI --- VK
+    DEMS --- PG_A
+    DEMS --- VK
+    PIPELINE -- "sidecar" --> Logging
+    TMS -- "sidecar" --> Logging
+
+    %% ── Server B → Server A (cross-server) ───────────────────────────────
+    TCSbe -- "postgres :15432" --> PG_A
+    TCSbe -- "NATS :14222" --> NATS_A
+    TCSbe -- "auth :3020" --> Auth
+    TCSbe -- "keycloak :8080" --> KC
+    TCSbe -- "admin :3100" --> Admin
+    TRSbe -- "auth :3020" --> Auth
+    TRSbe -- "admin :3100" --> Admin
+    CMSbe -- "auth :3020" --> Auth
+    CMSbe -- "NATS :14222" --> NATS_A
+    CMSbe -- "valkey :16379" --> VK
+
+    %% ── Server B internal ────────────────────────────────────────────────
+    TCSbe --- OS
+    TCSbe --- SFTP
+    TRSbe --- OS
+    CMSbe --- PG_B
+    CMSbe --- OS
+    CMSbe --- CDB
+    CMSbe --- FLW
+    FLW --- PG_B
+
+    %% ── Server B → Server C (direct — bypasses ALB) ──────────────────────
+    CMSbe -- "direct :8282" --> DLH
+
+    %% ── Server C → Server A (ETL cross-server) ───────────────────────────
+    NiFi -- "postgres ETL :15432" --> PG_A
+    NiFi -- "NATS :14222" --> NATS_A
+
+    %% ── Server C → Server B (ETL cross-server) ───────────────────────────
+    NiFi -- "postgres ETL :15433" --> PG_B
+    NiFi -- "opensearch :9200" --> OS
+
+    %% ── Server C internal ────────────────────────────────────────────────
+    NiFi --- Ozone
+    AO --- Ozone
+    DLH --- Ozone
+    JH --- Ozone
+    UP --- Tika
+    UP --- Solr
+    NiFi -- ":7619" --> AO
+```
+
+---
+
+## 2. Transaction Processing Pipeline
+
+The core Tazama flow: a financial message is submitted to the TMS, fanned out through the
+NATS-based rule evaluation pipeline, decisioned by TADP, and the resulting investigation alert
+is consumed by the CMS on Server B.
+
+DEAPI and DEMS run inside the `tazama-core` Docker project on **Server A** (launched as a
+pre-flight step for extensions) so they share the internal Docker network with NATS, postgres,
+and valkey. Their exterior ports (:3001, :3002) allow external callers (Server B frontends
+via ALB) to reach them across the network.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Client as Client<br/>(Postman / TCS Frontend)
+    participant ALB as ALB
+    participant TMS as TMS<br/>Server A :5000
+    participant PG_A as PostgreSQL<br/>Server A :5432
+    participant VK as Valkey<br/>Server A :6379
+    participant NATS as NATS<br/>Server A :4222
+    participant ED as Event Director<br/>Server A
+    participant Rules as Rule Processors<br/>Server A (901, 902 …)
+    participant TP as Typology Processor<br/>Server A
+    participant EF as Event Flow<br/>Server A
+    participant TADP as TADP<br/>Server A
+    participant RS as Relay Services<br/>Server A (rsef/rstp/rstadp)
+    participant CMSbe as CMS Backend<br/>Server B :3090
+    participant PG_B as PostgreSQL<br/>Server B :5432
+    participant OSrch as OpenSearch<br/>Server B :9200
+    participant DLH as Datalakehouse API<br/>Server C :8282
+
+    Client->>ALB: POST /v1/evaluate/iso20022/pacs.002.001.12
+    ALB->>TMS: forward to :5000
+    TMS->>PG_A: write raw transaction (raw_history DB)
+    TMS->>NATS: publish → stream: event-director
+    TMS-->>ALB: 200 Accepted
+    ALB-->>Client: 200 Accepted
+
+    NATS-->>ED: consume ← stream: event-director
+    ED->>PG_A: read rule configuration (configuration DB)
+    ED->>NATS: publish → per-rule streams (rule-901, rule-902, …)
+
+    par Rule evaluation (parallel, one per active rule)
+        NATS-->>Rules: consume ← rule-N stream
+        Rules->>PG_A: read rule config + raw/event history
+        Rules->>VK: check/update evaluation cache
+        Rules->>NATS: publish → stream: typology-processor
+    end
+
+    NATS-->>TP: consume ← rule result streams
+    TP->>PG_A: read typology configuration
+    TP->>VK: aggregate rule results per typology
+    TP->>NATS: publish → stream: interdiction-service-tp
+
+    NATS-->>EF: consume ← event-flow rule streams
+    EF->>PG_A: read event-flow rule config
+    EF->>VK: cache event-flow state
+    EF->>NATS: publish → stream: interdiction-service-ef
+
+    NATS-->>RS: rsef consumes ← interdiction-service-ef
+    RS->>NATS: republish → relay-service-nats-ef
+
+    NATS-->>RS: rstp consumes ← interdiction-service-tp
+    RS->>NATS: republish → relay-service-nats-tp
+
+    NATS-->>TADP: consume ← relay-service-nats-tp + relay-service-nats-ef
+    TADP->>PG_A: read TADP config (configuration DB)
+    TADP->>PG_A: write evaluation result (evaluation DB)
+    TADP->>NATS: publish → stream: investigation-service (alert)
+
+    NATS-->>RS: rstadp consumes ← investigation-service
+    RS->>NATS: republish → relay-service-nats-tadp
+
+    Note over CMSbe,NATS: CMS Backend (Server B) subscribes to<br/>investigation-service on Server A NATS :14222
+    NATS-->>CMSbe: deliver investigation alert (nats://core.tazama.internal:14222)
+    CMSbe->>PG_B: store case record (tazama_cms DB)
+    CMSbe->>OSrch: index alert (opensearch-node1:9200)
+
+    Note over CMSbe,DLH: CMS analyst opens the case — frontend requests gold lakehouse data
+    CMSbe->>DLH: GET /... (direct HTTP :8282, bypasses ALB)
+    DLH-->>CMSbe: return structured transaction / analytics data
+    CMSbe-->>Client: case detail with enriched data
+```
+
+---
+
+## 3. Data Enrichment and Event Monitoring (DEAPI / DEMS)
+
+DEAPI and DEMS are both co-hosted on **Server A** (tazama-core project). They are called by
+frontends via the ALB and by the NATS pipeline for enrichment callbacks.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor TCSfe as TCS Frontend<br/>Server B :5173
+    participant ALB as ALB
+    participant DEAPI as DEAPI<br/>Server A :3001
+    participant DEMS as DEMS<br/>Server A :3002
+    participant PG_A as PostgreSQL<br/>Server A :5432
+    participant VK as Valkey<br/>Server A :6379
+    participant NATS as NATS<br/>Server A :4222
+    participant Sidecar as Event Sidecar<br/>Server A :15000
+    participant LJ as Lumberjack<br/>Server A
+
+    Note over TCSfe,DEAPI: Data enrichment request from TCS frontend (via ALB)
+    TCSfe->>ALB: GET /enrichment/... (:3001)
+    ALB->>DEAPI: forward to Server A :3001
+    DEAPI->>PG_A: query enrichment DB
+    DEAPI->>VK: check enrichment cache
+    DEAPI-->>ALB: enrichment payload
+    ALB-->>TCSfe: return enriched data
+
+    Note over DEMS,NATS: DEMS listens on NATS for config change notifications
+    NATS-->>DEMS: consume ← stream: config.notification
+    DEMS->>PG_A: read updated configuration (configuration DB)
+    DEMS->>PG_A: query raw/event history DBs
+    DEMS->>VK: update monitoring state
+    DEMS->>NATS: publish → stream: dems.notification.response
+
+    Note over DEAPI,NATS: DEAPI listens for enrichment requests over NATS
+    NATS-->>DEAPI: consume ← stream: enrichment.notification
+    DEAPI->>PG_A: read enrichment DB
+    DEAPI->>VK: cache result
+    DEAPI->>NATS: publish → stream: enrichment.notification.response
+
+    Note over Sidecar,LJ: All services emit structured logs via sidecar
+    DEAPI->>Sidecar: log event (HTTP)
+    DEMS->>Sidecar: log event (HTTP)
+    Sidecar->>NATS: publish → subject: Lumberjack
+    NATS-->>LJ: consume ← Lumberjack
+    LJ->>LJ: write to stdout / log sink
+```
+
+---
+
+## 4. Tooling Frontend Authentication and API Flows
+
+TCS, TRS, and CMS frontends follow the same auth pattern: the frontend requests a JWT from
+the Auth Service (via the TMS auth endpoint or Keycloak), then the backend validates the JWT
+locally using the RSA public key.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor User as Analyst / User
+    participant CMSfe as CMS Frontend<br/>Server B :5175
+    participant CMSbe as CMS Backend<br/>Server B :3090
+    participant TCSfe as TCS Frontend<br/>Server B :5173
+    participant TCSbe as TCS Backend<br/>Server B :3010
+    participant TRSfe as TRS Frontend<br/>Server B :5174
+    participant TRSbe as TRS Backend<br/>Server B :3005
+    participant AuthSvc as Auth Service<br/>Server A :3020
+    participant KC as Keycloak<br/>Server A :8080
+    participant Admin as Admin API<br/>Server A :5100
+    participant PG_A as PostgreSQL<br/>Server A :15432
+    participant NATS as NATS<br/>Server A :14222
+    participant OS as OpenSearch<br/>Server B :9200
+    participant PG_B as PostgreSQL<br/>Server B :15433
+
+    Note over User,KC: Login flow (same for CMS, TCS, TRS)
+    User->>CMSfe: navigate to CMS
+    CMSfe->>KC: redirect to Keycloak :8080 (OIDC)
+    User->>KC: submit credentials
+    KC-->>CMSfe: ID token + access token
+    CMSfe->>AuthSvc: POST /v1/auth/login (exchange KC token → Tazama JWT)
+    AuthSvc->>KC: verify token with Keycloak :8080
+    KC-->>AuthSvc: token valid
+    AuthSvc-->>CMSfe: Tazama JWT (signed with RSA private key)
+
+    Note over CMSfe,CMSbe: All subsequent API calls carry the JWT
+    CMSfe->>CMSbe: GET /api/cases (Bearer JWT)
+    CMSbe->>CMSbe: verify JWT (RSA public key on disk)
+    CMSbe->>PG_B: query tazama_cms DB
+    CMSbe->>OS: search OpenSearch for case records
+    CMSbe-->>CMSfe: case list
+
+    Note over TCSfe,PG_A: TCS Backend — reads rule config from Server A postgres
+    User->>TCSfe: open Connection Studio
+    TCSfe->>TCSbe: GET /api/configurations (Bearer JWT)
+    TCSbe->>TCSbe: verify JWT
+    TCSbe->>PG_A: read configuration DB (:15432 cross-server)
+    TCSbe->>Admin: GET /admin/... (:3100)
+    TCSbe->>NATS: publish config change → stream: config.notification (:14222)
+    TCSbe-->>TCSfe: configuration data
+
+    Note over TRSfe,Admin: TRS Backend — rule management
+    User->>TRSfe: open Rule Studio
+    TRSfe->>TRSbe: GET /api/rules (Bearer JWT)
+    TRSbe->>TRSbe: verify JWT
+    TRSbe->>OS: query OpenSearch rule-studio-audit index
+    TRSbe->>Admin: GET /admin/rules (:3100)
+    TRSbe-->>TRSfe: rule list
+```
+
+---
+
+## 5. BIAR Data Pipeline (NiFi ETL and Analytics)
+
+NiFi orchestrates data movement between Server A's PostgreSQL, Server B's PostgreSQL and
+OpenSearch, and the Ozone object store on Server C. The Datalakehouse API exposes the processed
+(gold) data to the CMS backend.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant NiFi as NiFi<br/>Server C :8088
+    participant AO as Automation Orchestrator<br/>Server C :7619
+    participant DLH as Datalakehouse API<br/>Server C :8282
+    participant JH as JupyterHub<br/>Server C :8000
+    participant Ozone as Ozone S3G<br/>Server C :9878
+    participant Tika as Tika<br/>Server C :9998
+    participant Solr as Solr<br/>Server C :8983
+    participant UP as Unstructured Pipeline<br/>Server C
+    participant PG_A as PostgreSQL<br/>Server A :15432
+    participant PG_B as PostgreSQL<br/>Server B :15433
+    participant OS as OpenSearch<br/>Server B :9200
+    participant CMSbe as CMS Backend<br/>Server B :3090
+
+    Note over NiFi,PG_A: Scheduled ETL — extract transaction data from Server A
+    NiFi->>PG_A: JDBC query (raw_history, event_history, evaluation DBs)
+    PG_A-->>NiFi: raw transaction records
+
+    Note over NiFi,PG_B: Extract case/enrichment data from Server B
+    NiFi->>PG_B: JDBC query (tazama_cms, tazama_dwh DBs)
+    PG_B-->>NiFi: case and enrichment records
+    NiFi->>OS: query OpenSearch indices
+    OS-->>NiFi: alert / audit records
+
+    Note over NiFi,Ozone: Transform and load into Ozone object store (Hudi tables)
+    NiFi->>AO: POST /checksubmit (trigger Spark job)
+    AO->>Ozone: write Hudi table partitions (S3A :9878)
+    Ozone-->>AO: write confirmed
+    AO-->>NiFi: job complete
+
+    Note over NiFi,Ozone: NiFi also writes enriched parquet directly to Ozone
+    NiFi->>Ozone: PUT object (S3A :9878)
+
+    Note over UP,Solr: Unstructured document pipeline
+    UP->>Tika: extract text from documents (:9998)
+    Tika-->>UP: extracted text
+    UP->>Solr: index document (:8983)
+
+    Note over DLH,CMSbe: CMS backend reads gold lakehouse data on demand
+    CMSbe->>DLH: GET /api/transactions/... (:8282 direct from Server B)
+    DLH->>Ozone: read Hudi partition (S3A :9878)
+    Ozone-->>DLH: parquet data
+    DLH-->>CMSbe: structured gold data (JSON)
+
+    Note over JH,Ozone: Data scientist opens JupyterHub session
+    JH->>Ozone: mount Hudi warehouse via S3A (:9878)
+    JH->>JH: run PySpark / notebook analysis
+```
+
+---
+
+## 6. Cross-Server Connection Reference
+
+All ports listed here traverse the AWS VPC private subnet (`10.0.1.0/24`). They require the
+corresponding Security Group ingress rules to be in place.
+
+### Server B → Server A
+
+| Source service | Destination | Port | Protocol | Purpose |
+|---|---|---|---|---|
+| tcs-backend | PostgreSQL (Server A) | 15432 | TCP/JDBC | Read rule configuration DB |
+| tcs-backend | Auth Service | 3020 | TCP/HTTP | JWT validation |
+| tcs-backend | NATS | 14222 | TCP/NATS | Publish config.notification |
+| tcs-backend | Keycloak | 8080 | TCP/HTTP | OIDC token verification |
+| tcs-backend | Admin API | 3100 | TCP/HTTP | Admin operations |
+| trs-backend | Auth Service | 3020 | TCP/HTTP | JWT validation |
+| trs-backend | Admin API | 3100 | TCP/HTTP | Admin operations |
+| cms-backend | Auth Service | 3020 | TCP/HTTP | JWT validation |
+| cms-backend | NATS | 14222 | TCP/NATS | Subscribe: investigation-service |
+| cms-backend | Valkey | 16379 | TCP/RESP | Redis cache |
+
+### Server B → Server C
+
+| Source service | Destination | Port | Protocol | Purpose |
+|---|---|---|---|---|
+| cms-backend | Datalakehouse API | 8282 | TCP/HTTP | Gold lakehouse data (direct, not via ALB) |
+
+### Server C → Server A
+
+| Source service | Destination | Port | Protocol | Purpose |
+|---|---|---|---|---|
+| NiFi | PostgreSQL (Server A) | 15432 | TCP/JDBC | ETL extraction (raw_history, event_history, evaluation) |
+| NiFi | NATS | 14222 | TCP/NATS | Pipeline integration |
+
+### Server C → Server B
+
+| Source service | Destination | Port | Protocol | Purpose |
+|---|---|---|---|---|
+| NiFi | PostgreSQL (Server B) | 15433 | TCP/JDBC | ETL extraction (tazama_cms, tazama_dwh) |
+| NiFi | OpenSearch | 9200 | TCP/HTTP | ETL extraction (alert / audit indices) |
+
+### ALB → Servers (per-server, current port-based HTTP routing)
+
+> Ports with `†` have ALB listener target groups configured but the port is **not** currently
+> open in the ALB Security Group — those services are accessed via SSH tunnel (Phase E.1).
+> They will be opened to the internet when promoted to Phase F subdomain routing.
+
+| Target | Port | Service |
+|---|---|---|
+| Server A | 5000 | TMS API |
+| Server A | 3001 | DEAPI |
+| Server A | 3002 | DEMS |
+| Server A | 3020 | Auth Service |
+| Server A | 5100 | Admin API |
+| Server A | 8080 | Keycloak |
+| Server A | 5050 | pgAdmin (core) |
+| Server A | 6100 | Hasura |
+| Server B | 3005 | TRS Backend |
+| Server B | 3010 | TCS Backend |
+| Server B | 3090 | CMS Backend |
+| Server B | 5051 | pgAdmin (extensions) |
+| Server B | 5173 | TCS Frontend |
+| Server B | 5174 | TRS Frontend |
+| Server B | 5175 | CMS Frontend |
+| Server C | 8088 | NiFi UI |
+| Server C | 8000 `†` | JupyterHub |
+| Server C | 7619 `†` | Automation Orchestrator |
+| Server C | 8282 `†` | Datalakehouse API |
+
+### Operator-only (SSH tunnel via EICE, no SG inbound rules)
+
+| Server | Port | Service |
+|---|---|---|
+| Server C | 8983 | Solr UI |
+| Server C | 9876 | Ozone SCM |
+| Server C | 9878 | Ozone S3G |
+| Server C | 9888 | Ozone Recon UI |
+
+---
+
+## 7. NATS Stream Map (Server A)
+
+The full NATS message path through the Server A pipeline for a single transaction evaluation.
+
+```mermaid
+flowchart TD
+    subgraph Inbound["Inbound"]
+        TMS["TMS\n(HTTP entry point)"]
+    end
+
+    subgraph Pipeline["NATS Pipeline — Server A internal"]
+        direction TB
+        ED["Event Director"]
+        R901["rule-901"]
+        R902["rule-902"]
+        Rn["rule-N …"]
+        TP["Typology Processor"]
+        EF["Event Flow"]
+        TADP["TADP"]
+    end
+
+    subgraph Relay["Relay Services"]
+        RSEF["rsef\n(relay EF)"]
+        RSTP["rstp\n(relay TP)"]
+        RSTADP["rstadp\n(relay TADP)"]
+    end
+
+    subgraph External["External Consumers (cross-server)"]
+        CMSbe["CMS Backend\nServer B :3090\n(NATS :14222)"]
+    end
+
+    TMS -- "event-director" --> ED
+    ED -- "rule-901" --> R901
+    ED -- "rule-902" --> R902
+    ED -- "rule-N" --> Rn
+    R901 -- "rule result → typology-processor" --> TP
+    R902 -- "rule result → typology-processor" --> TP
+    Rn -- "rule result → typology-processor" --> TP
+    ED -- "event-flow streams" --> EF
+    TP -- "interdiction-service-tp" --> RSTP
+    EF -- "interdiction-service-ef" --> RSEF
+    RSTP -- "relay-service-nats-tp" --> TADP
+    RSEF -- "relay-service-nats-ef" --> TADP
+    TADP -- "investigation-service" --> RSTADP
+    TADP -- "investigation-service" --> CMSbe
+    RSTADP -- "relay-service-nats-tadp\n(downstream / monitoring)" --> External
+```

--- a/infra/aws/modules/security-groups/main.tf
+++ b/infra/aws/modules/security-groups/main.tf
@@ -282,11 +282,20 @@ resource "aws_security_group" "server_c" {
   }
 
   ingress {
-    description     = "Datalakehouse API"
+    description     = "Datalakehouse API (via ALB)"
     from_port       = 8282
     to_port         = 8282
     protocol        = "tcp"
     security_groups = [aws_security_group.alb.id]
+  }
+
+  # CMS backend on Server B calls the datalakehouse-api directly (not via ALB)
+  ingress {
+    description     = "CMS backend -> Datalakehouse API (direct)"
+    from_port       = 8282
+    to_port         = 8282
+    protocol        = "tcp"
+    security_groups = [aws_security_group.server_b.id]
   }
 
   ingress {

--- a/infra/aws/templates/env-biar.tpl
+++ b/infra/aws/templates/env-biar.tpl
@@ -10,3 +10,9 @@
 SERVER_A_HOST=core.tazama.internal
 SERVER_B_HOST=extensions.tazama.internal
 SERVER_C_HOST=biar.tazama.internal
+
+# Ozone S3G endpoint — Docker service name so all containers in tazama-biar use
+# the Docker bridge network.  biar/.env ships ${SERVER_C_HOST}:9878 which Docker
+# Compose interpolates to the EC2 hostname; port 9878 has no SG inbound rule.
+# This overlay entry ensures the correct value even if biar/.env is stale.
+S3A_ENDPOINT=http://s3g:9878


### PR DESCRIPTION
## Summary

Three related fixes bundled together.

### 1. Parameterise repo branch (`$Script:RepoBranch` + `var.repo_branch`)

All four places that previously hardcoded the git branch string now read from a single source:

- `infra/aws/scripts/helpers.ps1` — `$Script:RepoBranch = 'dev'` (one place to change for deploy scripts)
- `infra/aws/variables.tf` — `variable "repo_branch" { default = "dev" }` (one place to change for bootstrap)
- `infra/aws/main.tf` — passes `repo_branch = var.repo_branch` to `templatefile()`
- `infra/aws/templates/bootstrap.sh.tpl` — uses `${repo_branch}` template variable
- `infra/aws/scripts/deploy-core.ps1`, `deploy-extensions.ps1`, `deploy-biar.ps1` — use `$Script:RepoBranch`

### 2. Fix CMS `GOLD_LAKEHOUSE_TIMEOUT`

`extensions/env/cms.env` — added `GOLD_LAKEHOUSE_TIMEOUT=120000` (120 s). The env var was validated in the schema but never set, leaving the service at its 30 s hardcoded fallback — insufficient for Spark queries via the datalakehouse-api.

### 3. Fix Server C security group: allow Server B → port 8282 (datalakehouse-api)

The CMS backend (Server B) calls the datalakehouse-api (Server C, port 8282) directly — not via the ALB. The `server_c` SG only had an inbound 8282 rule from the ALB SG; this adds a second rule from `server_b` SG for the direct path.

**Root cause of live outage:** Server B had also drifted to `tazama-server-a-sg` instead of `tazama-server-b-sg` (live state drift, not an IaC bug — corrected on live infrastructure via `aws ec2 modify-instance-attribute`). The IaC was always correct for that part; a `tofu plan` will confirm no drift remains after merge.

**Docs updated:**
- `aws-deployment-instructions.md` C.3 — corrected the SG table (Server C was described as "outbound-only", which was wrong)
- `aws-deployment-instructions.md` F.5 — added cross-server connectivity check (Server B → Server C:8282) with SG drift detection guidance

### Files changed
- `infra/aws/scripts/helpers.ps1`
- `infra/aws/scripts/deploy-core.ps1`
- `infra/aws/scripts/deploy-extensions.ps1`
- `infra/aws/scripts/deploy-biar.ps1`
- `infra/aws/variables.tf`
- `infra/aws/main.tf`
- `infra/aws/templates/bootstrap.sh.tpl`
- `infra/aws/modules/security-groups/main.tf`
- `infra/aws/aws-deployment-instructions.md`
- `extensions/env/cms.env`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added timeout configuration for Lakehouse operations.
  * Updated security group rules for datalakehouse-api port access and clarified ALB-based connectivity.

* **Documentation**
  * Updated deployment instructions with revised Server C security group exposure guidance and cross-server connectivity validation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->