### PR TITLE
fix(biar): hardcode CouchDB URL and fix README drift (Breaks 3-6)

### DIFF
--- a/biar/README.md
+++ b/biar/README.md
@@ -313,10 +313,10 @@ All notebooks read Spark configuration from environment variables. The key varia
 
 | Variable | Default | Description |
 |---|---|---|
-| `S3A_ENDPOINT` | `http://<SERVER_C_HOST>:9878` | Ozone S3G endpoint for Spark S3A reads |
+| `S3A_ENDPOINT` | `http://s3g:9878` | Ozone S3G endpoint for Spark S3A reads |
 | `S3A_ACCESS_KEY` | `tazama` | Ozone S3 access key |
 | `S3A_SECRET_KEY` | `tazama` | Ozone S3 secret key |
-| `WAREHOUSE_ROOT` | `/opt/Tazama_Hudi_warehouse` | Path to the Hudi warehouse root inside the container |
+| `WAREHOUSE_ROOT` | `/opt/Tazama_Warehouse` | Path to the Hudi warehouse root inside the container |
 | `SPARK_DRIVER_MEMORY` | `4g` | Heap memory per user Spark session |
 
 These defaults match the values in `biar/env/jupyterlab.env` and the Ozone credentials in `biar/.env`. Override them in `jupyterlab.env` before deploying if your Ozone is configured differently.
@@ -398,13 +398,13 @@ To export a configured flow for reuse, use NiFi's built-in `Download flow defini
 
 ## 9.2. Apache Ozone bucket initialisation
 
-The `ozone-aws-cli` container automatically creates the `biar-bucket` bucket each time the stack is started (the `|| true` in the entrypoint makes the command idempotent if the bucket already exists). To interact with Ozone manually using the S3-compatible API:
+The `ozone-aws-cli` container automatically creates the `tazama` bucket each time the stack is started (the `|| true` in the entrypoint makes the command idempotent if the bucket already exists). The bucket name is controlled by `AWS_BUCKET_NAME` in `biar/.env`. To interact with Ozone manually using the S3-compatible API:
 
 ```
 docker exec ozone-aws-cli aws --endpoint-url http://s3g:9878 s3 ls
 ```
 
-The Ozone S3G access key is `admin` and secret key is `admin` in the default configuration. These are committed defaults appropriate for a local development deployment only.
+The Ozone S3G access key is `tazama` and secret key is `tazama` in the default configuration (set via `S3A_ACCESS_KEY` and `S3A_SECRET_KEY` in `biar/.env`). These are committed defaults appropriate for a local development deployment only.
 
 ## 9.3. Docker Compose YAML structure
 

--- a/biar/env/unstructured-pipeline.env
+++ b/biar/env/unstructured-pipeline.env
@@ -2,7 +2,9 @@ NODE_ENV=dev
 FUNCTION_NAME=biar-processor
 
 # CouchDB Configuration
-COUCHDB_URL=http://simon:1234@${SERVER_B_HOST}:5984/cms-evidence
+# CouchDB is on Server B (extensions.tazama.internal). ${SERVER_B_HOST} must NOT be
+# used here: env_file: values are not interpolated by Docker Compose.
+COUCHDB_URL=http://simon:1234@extensions.tazama.internal:5984/cms-evidence
 
 # Processing Services
 # Docker service names — tika, solr, and nifi are in the same tazama-biar project.

--- a/infra/aws/templates/env-biar.tpl
+++ b/infra/aws/templates/env-biar.tpl
@@ -16,3 +16,9 @@ SERVER_C_HOST=biar.tazama.internal
 # Compose interpolates to the EC2 hostname; port 9878 has no SG inbound rule.
 # This overlay entry ensures the correct value even if biar/.env is stale.
 S3A_ENDPOINT=http://s3g:9878
+
+# CouchDB URL for unstructured-pipeline — CouchDB lives on Server B.
+# biar/env/unstructured-pipeline.env now hardcodes extensions.tazama.internal,
+# but this overlay ensures the gitignored biar/.env is also correct if it ever
+# surfaces this key.
+COUCHDB_URL=http://simon:1234@extensions.tazama.internal:5984/cms-evidence


### PR DESCRIPTION
## Summary

Fixes the remaining post-Ozone biar pipeline break (Break 6: `COUCHDB_URL`) and corrects documentation drift in `biar/README.md`.

### Break 6 — `COUCHDB_URL` in `unstructured-pipeline.env`

**Root cause:** `COUCHDB_URL=${SERVER_B_HOST}:5984/...` — `env_file:` entries are passed verbatim by Docker Compose; shell variable interpolation does not occur. CouchDB is on Server B (a different host) so a Docker service name cannot be used either.

**Fix:** Hardcode `COUCHDB_URL=http://simon:1234@extensions.tazama.internal:5984/cms-evidence` (the private DNS name for Server B, always reachable within the VPC). Added inline comment explaining why `${SERVER_B_HOST}` cannot be used here.

**Also updated** `infra/aws/templates/env-biar.tpl` with `COUCHDB_URL` so future `Set-RemoteEnvOverlay` calls preserve the correct value.

### `biar/README.md` drift fixes

Section 7.4 (notebook env var defaults table):
- `S3A_ENDPOINT`: `http://<SERVER_C_HOST>:9878` → `http://s3g:9878` (Docker service name; `env_file:` does not interpolate `${...}`, and `s3g` resolves in both local and AWS deployments since JupyterHub is in the `tazama-biar` project)
- `WAREHOUSE_ROOT`: `/opt/Tazama_Hudi_warehouse` → `/opt/Tazama_Warehouse` (matches the container-side mount in `docker-compose.hub.biar.yaml` and the value fixed in PR #168)

Section 9.2 (Ozone bucket initialisation):
- Bucket name: `biar-bucket` → `tazama` (actual value of `AWS_BUCKET_NAME` in `biar/.env`); noted that it is configurable
- S3G credentials: `admin`/`admin` → `tazama`/`tazama` (actual values of `S3A_ACCESS_KEY`/`S3A_SECRET_KEY` in `biar/.env`)

### Files changed

| File | Change |
|---|---|
| `biar/env/unstructured-pipeline.env` | Hardcode `COUCHDB_URL` with private DNS; add explanatory comment |
| `infra/aws/templates/env-biar.tpl` | Add `COUCHDB_URL` to overlay template |
| `biar/README.md` | Fix 4 stale values in sections 7.4 and 9.2 |

### Related

- Depends on / follows PR #168 (`tazama/refactor/parameterise-repo-branch`) which fixed Breaks 1–5 and the JupyterHub warehouse path
- All fixes verified live on Server C

### Testing

All six biar containers confirmed running on Server C after applying these fixes:
```
biar-unstructured-pipeline   Up
biar-nifi                    Up
biar-automation-orchestrator Up
biar-datalakehouse-api       Up
biar-jupyterhub              Up
```
`COUCHDB_URL` confirmed via `docker inspect biar-unstructured-pipeline`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated BIAR environment setup documentation with current S3 endpoint hostname, warehouse paths, and credential defaults for Ozone configuration.
  * Updated default bucket naming and clarified environment variable control points.

* **Chores**
  * Updated CouchDB connection configuration to use direct internal hostname instead of variable placeholders.
  * Added clarifying notes on Docker Compose environment file handling and variable interpolation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->