### PR TITLE
fix(biar): correct nifi-init env_file load order so nifi.env takes precedence over .env

### DIFF
--- a/biar/docker-compose.utils.init.yaml
+++ b/biar/docker-compose.utils.init.yaml
@@ -29,8 +29,8 @@ services:
     container_name: nifi-init
     restart: on-failure
     env_file:
-      - env/nifi.env
       - .env
+      - env/nifi.env
     depends_on:
       - nifi
     volumes:

--- a/infra/aws/aws-deployment-instructions.md
+++ b/infra/aws/aws-deployment-instructions.md
@@ -1165,6 +1165,12 @@ They override the local-dev `SERVER_*_HOST` values in `extensions/.env` and
 
 `core/.env` has no cross-server host variables, so no overlay is needed.
 
+`env-extensions.tpl` is applied to **both** Server A and Server B by
+`deploy-extensions.ps1`. DEMS and DEAPI run on Server A (inside the
+`tazama-core` project) and use `extensions/.env` for their `CORS_ORIGINS`
+value; without the overlay `SERVER_B_HOST` remains at the local-dev default
+`localhost`.
+
 Files created:
 - [infra/aws/templates/env-extensions.tpl](full-stack-docker-tazama/infra/aws/templates/env-extensions.tpl)
 - [infra/aws/templates/env-biar.tpl](full-stack-docker-tazama/infra/aws/templates/env-biar.tpl)
@@ -1173,8 +1179,8 @@ Files created:
 
 | Variable | Committed default | Overlay value | Reason |
 |---|---|---|---|
-| `SERVER_A_HOST` | `10.0.1.10` | `core.tazama.internal` | Private DNS for cross-stack calls |
-| `SERVER_B_HOST` | `10.0.1.20` | `extensions.tazama.internal` | Private DNS |
+| `SERVER_A_HOST` | `host.docker.internal` | `core.tazama.internal` | Private DNS for cross-stack calls |
+| `SERVER_B_HOST` | `localhost` | `extensions.tazama.internal` | Private DNS; also drives `CORS_ORIGINS` in deapi/dems |
 | `ADMIN_SERVICE_URL` | container-internal port | `http://core.tazama.internal:5100` | Correct admin port |
 | `TRS_API_URL` / `TCS_API_URL` / `CMS_API_URL` | localhost defaults | Public ALB subdomains | Browser-facing VITE_ vars |
 | `SIMULATION_ENDPOINT` / `ADMIN_ENDPOINT` | localhost defaults | Public ALB subdomains | Browser-facing VITE_ vars |
@@ -1413,21 +1419,26 @@ docker compose -p tazama-core \
 
 [infra/aws/scripts/deploy-extensions.ps1](full-stack-docker-tazama/infra/aws/scripts/deploy-extensions.ps1)
 
-1. **Server A** - adds DEMS + DEAPI to the running `tazama-core` project:
+1. **Server A** - copies `extensions/.env` and applies `templates/env-extensions.tpl` overlay:
+   sets `SERVER_A_HOST=core.tazama.internal` and `SERVER_B_HOST=extensions.tazama.internal`.
+   DEMS and DEAPI run on Server A and consume `extensions/.env` for their `CORS_ORIGINS`
+   value; without this overlay `SERVER_B_HOST` stays at the local-dev default `localhost`.
+
+2. **Server A** - pulls latest repo then adds DEMS + DEAPI to the running `tazama-core` project:
    ```
    cd extensions/ && docker compose -p tazama-core \
-     -f ./docker-compose.dev.extensions.apis.yaml up -d
+     -f ./docker-compose.hub.extensions.apis.yaml up -d
    ```
    These APIs must be reachable before TCS/TRS backends start on Server B.
 
-2. **Server B** - waits for bootstrap (up to 15 min)
-3. **Server B** - applies `templates/env-extensions.tpl` overlay to `extensions/.env`:
+3. **Server B** - waits for bootstrap (up to 15 min)
+4. **Server B** - applies `templates/env-extensions.tpl` overlay to `extensions/.env`:
    sets `SERVER_A_HOST=core.tazama.internal` and `SERVER_B_HOST=extensions.tazama.internal`
-4. **Server B** - if `-Password` is supplied, applies a second in-memory credential overlay to `extensions/.env` and all `extensions/env/` service env files: sets `POSTGRES_PASSWORD`, `DB_PASSWORD`, `SPRING_DATASOURCE_PASSWORD`, and `CONFIGURATION_DATABASE_PASSWORD`
-5. **Server B** - SCP `core/auth/test-public-key.pem` → `extensions/auth/`
+5. **Server B** - if `-Password` is supplied, applies a second in-memory credential overlay to `extensions/.env` and all `extensions/env/` service env files: sets `POSTGRES_PASSWORD`, `DB_PASSWORD`, `SPRING_DATASOURCE_PASSWORD`, and `CONFIGURATION_DATABASE_PASSWORD`
+6. **Server B** - SCP `core/auth/test-public-key.pem` → `extensions/auth/`
    (required by TCS/TRS for JWT validation; on single-machine dev the bat
    script copies it automatically - here we do it from the local repo)
-6. **Server B** - starts the extensions stack:
+7. **Server B** - starts the extensions stack:
    ```
    docker compose -p tazama-extensions \
      -f ./docker-compose.extensions.infrastructure.yaml \

--- a/infra/aws/aws-deployment-instructions.md
+++ b/infra/aws/aws-deployment-instructions.md
@@ -2861,10 +2861,18 @@ In the group, go to **Permissions → Add permissions → Create inline policy**
     {
       "Sid": "AllowEICETunnel",
       "Effect": "Allow",
-      "Action": [
-        "ec2-instance-connect:OpenTunnel",
-        "ec2-instance-connect:SendSSHPublicKey"
-      ],
+      "Action": "ec2-instance-connect:OpenTunnel",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/Name": ["tazama-eice"]
+        }
+      }
+    },
+    {
+      "Sid": "AllowSendSSHPublicKey",
+      "Effect": "Allow",
+      "Action": "ec2-instance-connect:SendSSHPublicKey",
       "Resource": "*",
       "Condition": {
         "StringEquals": {
@@ -2885,9 +2893,11 @@ In the group, go to **Permissions → Add permissions → Create inline policy**
 }
 ```
 
-`ec2-instance-connect` actions do not support account-scoped ARNs in the resource field — `"*"` is the correct and AWS-documented form. The `Condition` block scopes tunnel access to only the three Tazama servers by their `Name` tag, which the OpenTofu configuration sets automatically.
+> **Important:** `OpenTunnel` and `SendSSHPublicKey` must be in separate statements with different conditions because they operate on different resource types. `OpenTunnel`'s resource is the EICE endpoint (tagged `tazama-eice`); `SendSSHPublicKey`'s resource is the EC2 instance (tagged with the server name). Combining them in one statement causes `OpenTunnel` to be denied because the endpoint name never matches the server names.
 
-To restrict a user to a subset of servers, simply remove the unwanted server names from the array. For example, to grant access to Server B and C only, remove `"tazama-server-a"` from the list.
+`ec2-instance-connect` actions do not support account-scoped ARNs in the resource field — `"*"` is the correct and AWS-documented form. The `Condition` blocks scope access to the specific EICE endpoint and the named Tazama servers, using `Name` tags that the OpenTofu configuration sets automatically.
+
+To restrict a user to a subset of servers, simply remove the unwanted server names from the `AllowSendSSHPublicKey` condition array. For example, to grant access to Server B and C only, remove `"tazama-server-a"` from the list.
 
 **2c — Create the IAM user:**
 
@@ -2907,6 +2917,15 @@ This creates a user with no console access, no permissions outside the group, an
 
 In the AWS Console go to **IAM → User groups → tazama-server-operators → Users → Add users** and select the user. Their permissions are now inherited from the group. To revoke access later, remove them from the group without touching the policy.
 
+
+> **Important — existing users getting `AccessDeniedException`:** If a user's SSH connection fails with `AccessDeniedException: not authorized to perform ec2-instance-connect:OpenTunnel`, they have not been added to the `tazama-server-operators` group (or the group was not set up yet). This is the only fix — SSH key setup alone is not enough. All of the following steps can be done entirely in the AWS Console:
+>
+> **If the group already exists** - simply add the user to it:
+> 1. Go to **IAM → User groups → tazama-server-operators**
+> 2. Click **Users → Add users** and select the affected user
+>
+> **If the group does not exist yet** - complete Steps 2a-2d above first, then add the user.
+ 
 #### Step 3 — User: install and configure the AWS CLI
 
 Send the user their **Access key ID** and **Secret access key** along with the following instructions.
@@ -2949,7 +2968,7 @@ ssh-keygen -t ed25519 -C "their-name@example.com" -f "$env:USERPROFILE\.ssh\taza
 
 This creates a private key (`tazama_ed25519`) and a public key (`tazama_ed25519.pub`). They must keep the private key secure and share only the public key with you.
 
-#### Step 4 — Add the user's public key to the EC2 instance(s)
+#### Step 5 — Add the user's public key to the EC2 instance(s)
 
 From your own workstation (which already has access), copy their public key into the `~/.ssh/authorized_keys` file on each instance they need to access.
 
@@ -2994,7 +3013,7 @@ Invoke-RemoteCommand -InstanceId $out.ServerC_InstanceId -Command `
   "echo '$pubKey' >> ~/.ssh/authorized_keys"
 ```
 
-#### Step 5 — User: set up the SSH config shortcut
+#### Step 6 — User: set up the SSH config shortcut
 
 The easiest way to connect is via an SSH config file. This lets the user run `ssh tazama-a` (or `tazama-b` / `tazama-c`) directly without specifying flags each time.
 
@@ -3041,7 +3060,7 @@ Note there is no `--profile` flag here — the user configured a default profile
 ssh tazama-a
 ```
 
-#### Step 6 — Viewing Docker container logs
+#### Step 7 — Viewing Docker container logs
 
 Once connected via SSH, the user can view logs for any running container:
 

--- a/infra/aws/scripts/deploy-extensions.ps1
+++ b/infra/aws/scripts/deploy-extensions.ps1
@@ -42,10 +42,19 @@ $idB = $out.ServerB_InstanceId
 Write-Host "[Server A] Instance ID: $idA"
 Write-Host "[Server B] Instance ID: $idB"
 
-# -- 1. Server A: copy extensions .env ---------------------------------------
-Write-Host '[Server A] Copying extensions/.env...' 
+# -- 1. Server A: copy extensions .env and apply overlay ---------------------
+# DEMS and DEAPI run on Server A inside the tazama-core Docker project.
+# They consume extensions/.env for SERVER_B_HOST (used in CORS_ORIGINS).
+# Copy the repo's local-dev defaults first, then apply the same overlay that
+# Server B receives so SERVER_B_HOST resolves to extensions.tazama.internal.
+Write-Host '[Server A] Copying extensions/.env...'
 $localExtEnv = Join-Path $PSScriptRoot '..\..\..\extensions\.env'
 Copy-ToRemote -InstanceId $idA -LocalPath $localExtEnv -RemotePath "$Script:RemoteRepo/extensions/.env"
+
+Write-Host '[Server A] Applying .env overlay to extensions/.env...'
+$overlayFile = Join-Path $PSScriptRoot '..\templates\env-extensions.tpl'
+Set-RemoteEnvOverlay -InstanceId $idA -OverlayFile $overlayFile -RemoteEnvFile "$Script:RemoteRepo/extensions/.env"
+Write-Host '[Server A] .env overlay applied.' -ForegroundColor Green
 
 # -- 2. Server A: pull latest repo then add DEMS + DEAPI ---------------------
 # DEMS and DEAPI run inside the tazama-core Docker project on Server A.


### PR DESCRIPTION
## Summary

Three fixes:

### 1. `biar/docker-compose.utils.init.yaml` — swap `env_file` order in `nifi-init`

`nifi-init` listed `env/nifi.env` first and `.env` second. Docker Compose applies `env_file` entries in order, so later files override earlier ones. Any key present in `.env` (e.g. `PB_OZONE_ENDPOINT` or `PB_HTTP_VALUE` carrying stale EC2 hostname values from a previous deployment) would silently override the correct Docker service-name values in `nifi.env`.

**Before:**
```yaml
env_file:
  - env/nifi.env
  - .env
```

**After:**
```yaml
env_file:
  - .env
  - env/nifi.env
```

`nifi.env` is now the authoritative source for NiFi parameter values and always wins.

### 2. `infra/aws/aws-deployment-instructions.md` — fix duplicate Step 4 heading

The "How do I give another user SSH access" section had two consecutive `#### Step 4` headings. Renumbered the second Step 4 → 5, Step 5 → 6, Step 6 → 7.

### 3. `infra/aws/scripts/deploy-extensions.ps1` — apply env overlay to Server A

DEMS and DEAPI run on Server A (inside the `tazama-core` Docker project) and consume `extensions/.env` for `SERVER_B_HOST`, which Docker Compose expands into `CORS_ORIGINS` in `deapi.env` and `dems.env`.

`deploy-extensions.ps1` already copied `extensions/.env` to Server A before starting the DEMS/DEAPI containers, but it only applied the `env-extensions.tpl` overlay to Server B. The repo default `SERVER_B_HOST=localhost` was therefore left in place on Server A, causing all browser CORS preflight requests to be rejected with a 403.

**Fix:** call `Set-RemoteEnvOverlay` with `env-extensions.tpl` against Server A's `extensions/.env` immediately after copying it — before `docker compose up`. The overlay sets `SERVER_B_HOST=extensions.tazama.internal`, so `CORS_ORIGINS` resolves correctly on both servers.

Also updated `aws-deployment-instructions.md` (D.3 and C.7) to reflect the Server A overlay step, renumber the step list, fix a stale compose file reference (`dev` → `hub`), and correct the committed-default values in the overlay table.

## Related

Follows on from PR #170 (warehouse path fix). The NiFi parameter context on Server C was found to contain stale `biar.tazama.internal` hostnames injected by `nifi-init` before the `nifi.env` fixes in PR #168 were applied — this root-cause fix prevents the same from happening on the next container recreate.

The DEAPI/DEMS CORS issue was discovered during the same deployment recon pass; the live env was patched directly on Server A and this commit closes the deploy-script gap that caused it.