### PR TITLE
feat(extensions): expose DEAPI/DEMS via ALB and fix OpenSearch startup ordering

### DIFF
--- a/extensions/docker-compose.hub.extensions.yaml
+++ b/extensions/docker-compose.hub.extensions.yaml
@@ -11,8 +11,10 @@ services:
     ports:
       - ${TCS_PORT}:3010
     depends_on:
-      - sftp
-      - opensearch-node1
+      sftp:
+        condition: service_started
+      opensearch-node1:
+        condition: service_healthy
     volumes:
       - ./auth:/auth:ro
 
@@ -40,7 +42,8 @@ services:
       - .env
     restart: always
     depends_on:
-      - opensearch-node1
+      opensearch-node1:
+        condition: service_healthy
     ports:
       - ${TRS_BACKEND_PORT}:3005
     volumes:
@@ -69,9 +72,12 @@ services:
     container_name: tazama-cms-backend
     restart: unless-stopped
     depends_on:
-      - migrate
-      - flowable
-      - opensearch-node1
+      migrate:
+        condition: service_completed_successfully
+      flowable:
+        condition: service_started
+      opensearch-node1:
+        condition: service_healthy
     env_file:
       - env/cms.env
       - .env

--- a/infra/aws/modules/alb/main.tf
+++ b/infra/aws/modules/alb/main.tf
@@ -24,6 +24,8 @@ locals {
     tms          = { port = 5000, server = "a" }
     admin        = { port = 5100, server = "a" }
     auth         = { port = 3020, server = "a" }
+    deapi        = { port = 3001, server = "a" }
+    dems         = { port = 3002, server = "a" }
     keycloak     = { port = 8080, server = "a" }
     pgadmin      = { port = 5050, server = "a" }
     hasura       = { port = 6100, server = "a" }
@@ -47,6 +49,7 @@ locals {
   }
 
   # Keycloak does not respond with 200 on /, use /health/ready instead.
+  # CMS and TRS/TCS APIs (NestJS) have no /health route; Swagger UI at /api/docs returns 200.
   health_check_paths = {
     keycloak    = "/health/ready"
     nifi        = "/nifi-api/system-diagnostics"
@@ -54,6 +57,9 @@ locals {
     pgadmin     = "/"
     pgadmin-ext = "/"
     jupyterhub  = "/hub/health"
+    cms-api     = "/api/docs"
+    trs-api     = "/api/docs"
+    tcs-api     = "/api/docs"
   }
 }
 

--- a/infra/aws/modules/dns-public/main.tf
+++ b/infra/aws/modules/dns-public/main.tf
@@ -10,6 +10,12 @@ resource "aws_route53_zone" "public" {
   tags = {
     Name = "${var.prefix}-public-zone"
   }
+
+  lifecycle {
+    # Deleting a hosted zone destroys the NS delegation at the registrar.
+    # Never allow Tofu to destroy this resource automatically.
+    prevent_destroy = true
+  }
 }
 
 # ---------------------------------------------------------------------------
@@ -22,6 +28,9 @@ resource "aws_acm_certificate" "wildcard" {
 
   lifecycle {
     create_before_destroy = true
+    # Prevent accidental destruction of the validated certificate.
+    # Re-issuing forces re-validation and breaks HTTPS until DNS propagates.
+    prevent_destroy = true
   }
 
   tags = {
@@ -66,6 +75,8 @@ locals {
     tms                     = var.target_group_arns["tms"]
     admin                   = var.target_group_arns["admin"]
     auth                    = var.target_group_arns["auth"]
+    deapi                   = var.target_group_arns["deapi"]
+    dems                    = var.target_group_arns["dems"]
     keycloak                = var.target_group_arns["keycloak"]
     pgadmin                 = var.target_group_arns["pgadmin"]
     hasura                  = var.target_group_arns["hasura"]
@@ -103,6 +114,8 @@ locals {
     automation-orchestrator = 17
     datalakehouse-api       = 18
     jupyter                 = 19
+    deapi                   = 20
+    dems                    = 21
   }
 }
 

--- a/infra/aws/modules/security-groups/main.tf
+++ b/infra/aws/modules/security-groups/main.tf
@@ -70,6 +70,14 @@ resource "aws_security_group" "alb" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  ingress {
+    description = "DEAPI / DEMS (Server A)"
+    from_port   = 3001
+    to_port     = 3002
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   # Server B service ports
   ingress {
     description = "TRS / TCS / CMS backends"
@@ -291,7 +299,7 @@ resource "aws_security_group" "server_c" {
 
   # CMS backend on Server B calls the datalakehouse-api directly (not via ALB)
   ingress {
-    description     = "CMS backend -> Datalakehouse API (direct)"
+    description     = "CMS backend to Datalakehouse API (direct)"
     from_port       = 8282
     to_port         = 8282
     protocol        = "tcp"


### PR DESCRIPTION
## Summary

Two independent fixes applied this session.

### 1. Expose DEAPI and DEMS via ALB (`infra/aws/`)

DEAPI (port 3001) and DEMS (port 3002) run on Server A but were never wired into the ALB, so they were only reachable on the private network. This adds them end-to-end.

**`infra/aws/modules/alb/main.tf`**
- Add `deapi` and `dems` to `local.services` with `port` and `server = "a"`
- Add `/api/docs` as the health check path for `cms-api`, `trs-api`, and `tcs-api` - these are NestJS services that have no `/health` route; the Swagger UI at `/api/docs` returns 200

**`infra/aws/modules/dns-public/main.tf`**
- Add `deapi` and `dems` to `subdomain_map` and `priority_map` (priorities 20 and 21)
- Add `lifecycle { prevent_destroy = true }` to the Route 53 zone and ACM wildcard certificate to prevent accidental destruction

**`infra/aws/modules/security-groups/main.tf`**
- Add ALB SG ingress rule for ports 3001-3002
- Fix existing SG description: `->` contains `>` which AWS rejects; changed to `to`

Changes have been applied (`tofu apply`) against the ap-south-1 environment.

---

### 2. Fix OpenSearch startup ordering (`extensions/docker-compose.hub.extensions.yaml`)

After a server reboot, OpenSearch takes ~60 seconds to initialise. The three backends that depend on it (`tcs-backend`, `trs-backend`, `cms-backend`) were using a plain `depends_on` reference, which only waits for the container to *start* - not for OpenSearch to be ready. This caused them to hit connection refused and enter crash backoff on every reboot.

OpenSearch already has a healthcheck defined (cluster health endpoint, 60s `start_period`, 20s interval, 10 retries). Change all three backends to `condition: service_healthy`.

Also tighten `cms-backend`'s `migrate` dependency to `service_completed_successfully` - `migrate` is a one-shot container that exits 0 when done; `service_started` was not the right condition.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DEAPI and DEMS services with dedicated health monitoring and traffic routing.

* **Chores**
  * Improved service startup reliability through optimized dependency management.
  * Enhanced infrastructure protection against accidental deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->