### PR TITLE
feat(extensions): add Voila notebook server service to CMS stack

### DIFF
--- a/extensions/docker-compose.dev.extensions.yaml
+++ b/extensions/docker-compose.dev.extensions.yaml
@@ -115,3 +115,20 @@ services:
       - VITE_ALLOWED_HOSTS=all
     ports:
       - "${CMS_FRONTEND_PORT}:5175"
+
+  voila:
+    image: !reset null
+    build:
+      context: https://github.com/tazama-lf/case-management-system.git#${CMS_BRANCH}
+      dockerfile: Dockerfile.viola
+      args:
+        - GH_TOKEN
+    container_name: tazama-cms-voila
+    restart: unless-stopped
+    env_file:
+      - ./env/cms.env
+      - .env
+    environment:
+      - CASE_MGMT_BACKEND_URL=http://tazama-cms-backend:3090
+    ports:
+      - "${VOILA_PORT}:8866"

--- a/extensions/docker-compose.hub.extensions.yaml
+++ b/extensions/docker-compose.hub.extensions.yaml
@@ -98,3 +98,15 @@ services:
       - VITE_ALLOWED_HOSTS=all
     ports:
       - "${CMS_FRONTEND_PORT}:5175"
+
+  voila:
+    container_name: tazama-cms-voila
+    image: tazamaorg/case-management-system-voila:${TAZAMA_VERSION}
+    restart: unless-stopped
+    env_file:
+      - env/cms.env
+      - .env
+    environment:
+      - CASE_MGMT_BACKEND_URL=http://tazama-cms-backend:3090
+    ports:
+      - "${VOILA_PORT}:8866"

--- a/extensions/env/cms.env
+++ b/extensions/env/cms.env
@@ -77,7 +77,7 @@ COUCHDB_USER=simon
 COUCHDB_PASSWORD=1234
 
 # Visualization and Lakehouse
-VOILA_URL=http://tazama-cms-viola:8866
+VOILA_URL=http://tazama-cms-voila:8866
 GOLD_LAKEHOUSE_API_URL=http://${SERVER_C_HOST}:8282
 GOLD_LAKEHOUSE_TIMEOUT=120000
 
@@ -94,4 +94,4 @@ OPENSEARCH_REFRESH=true
 VITE_APP_NAME="Tazama Case Management System"
 VITE_APP_VERSION=0.0.1
 VITE_CRYPTO_KEY=rCRrt08XYmYZrUoKffOQWXa327AJyBxv
-VOILA_URL=http://tazama-cms-viola:8866
+VOILA_URL=http://tazama-cms-voila:8866


### PR DESCRIPTION
## Summary

Restores the Voila notebook server that was originally part of the `docker-tazama-plus` CMS stack but was not carried over when the stack was split into server-specific folders.

Voila serves the CMS visualisation notebooks (account network, alert history, conditions timeline, counterparty network, transaction network, transaction viz) and is consumed internally by the CMS frontend JS via `VOILA_URL`.

## Changes

**`extensions/docker-compose.hub.extensions.yaml`**
- Add `voila` service using published image `tazamaorg/case-management-system-voila:${TAZAMA_VERSION}`
- `container_name: tazama-cms-voila`
- Overrides `CASE_MGMT_BACKEND_URL` to resolve via container name (`tazama-cms-backend:3090`) rather than the hardcoded IP in the Dockerfile
- Port: `${VOILA_PORT}:8866`

**`extensions/docker-compose.dev.extensions.yaml`**
- Add `voila` service with dev build from CMS repo using `Dockerfile.viola`
- Note: the `Dockerfile.viola` filename is a pre-existing typo tracked in [case-management-system#89](https://github.com/tazama-lf/case-management-system/issues/89) and will be corrected there

**`extensions/env/cms.env`**
- Fix `VOILA_URL` container name typo: `tazama-cms-viola` -> `tazama-cms-voila` (both occurrences)

## Notes

- `VOILA_PORT=18866` must be added to the gitignored `extensions/.env` on each host before deploying
- Service is internal-only (no ALB wiring required); the CMS frontend accesses it via `VOILA_URL` on the internal Docker network
- The `case-management-system` image must be built and published as `tazamaorg/case-management-system-voila` before this can be deployed