### PR TITLE
docs(extensions): document Voila service in READMEs and deployment guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The extensions stack provides the browser-based configuration studios and case m
 - Transaction Configuration Studio (TCS) -- API port 3010, UI port 5173
 - Transaction Rule Studio (TRS) -- API port 3005, UI port 5174
 - Case Management System (CMS) -- API port 3090, UI port 5175
+- Voila notebook server -- port 18866
 - pgAdmin (optional) -- port 5051
 
 **Launcher:** `extensions/tazama-extensions.bat` (Windows) / `extensions/tazama-extensions.sh` (Unix)

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -230,6 +230,7 @@ These infrastructure services are started as part of the `tazama-extensions` Com
 | TRS frontend | `trs-frontend` | 5174 | Transaction Rule Studio web UI |
 | CMS backend | `tazama-cms-backend` | 3090 | Case Management System API |
 | CMS frontend | `tazama-cms-frontend` | 5175 | Case Management System web UI |
+| Voila | `tazama-cms-voila` | 18866 | Voila notebook server - serves CMS visualisation notebooks (account network, alert history, conditions timeline, counterparty network, transaction graphs) embedded in the CMS frontend |
 
 <div style="text-align: right"><a href="#top">Top</a></div>
 
@@ -252,6 +253,7 @@ After a successful deployment, the following web interfaces are accessible from 
 #### Case Management System (CMS)
 - CMS API: <http://localhost:3090>
 - CMS UI: <http://localhost:5175>
+- Voila notebooks: <http://localhost:18866>
 
 #### Infrastructure
 - OpenSearch: <http://localhost:9200>

--- a/extensions/docker-compose.dev.extensions.yaml
+++ b/extensions/docker-compose.dev.extensions.yaml
@@ -120,7 +120,7 @@ services:
     image: !reset null
     build:
       context: https://github.com/tazama-lf/case-management-system.git#${CMS_BRANCH}
-      dockerfile: Dockerfile.viola
+      dockerfile: Dockerfile.voila
       args:
         - GH_TOKEN
     container_name: tazama-cms-voila

--- a/extensions/docker-compose.dev.extensions.yaml
+++ b/extensions/docker-compose.dev.extensions.yaml
@@ -131,4 +131,4 @@ services:
     environment:
       - CASE_MGMT_BACKEND_URL=http://tazama-cms-backend:3090
     ports:
-      - "${VOILA_PORT}:8866"
+      - "${VOILA_PORT:-18866}:8866"

--- a/infra/aws/aws-deployment-instructions.md
+++ b/infra/aws/aws-deployment-instructions.md
@@ -217,7 +217,7 @@ Three private EC2 instances sit behind an Application Load Balancer. No instance
     │  keycloak:8080 │  │ trs-api:3005 │  │ dlh-api    :8282│
     │  hasura  :6100 │  │ cms    :5175 │  │ solr       :8983│
     │  pgadmin :5050 │  │ cms-api:3090 │  │ ozone-scm  :9876│
-    │  nats    :14222│  │ pgadmin:5051 │  │ ozone-s3g  :9878│
+    │  nats    :14222│  │ voila :18866 │  │ ozone-s3g  :9878│
     │  postgres:15432│  │ postgres:15433  │ ozone-recon:9888│
     │  valkey  :16379│  │ opensrch:9200│  └────────┬────────┘
     └────────────────┘  └──────┬───────┘           │
@@ -2029,6 +2029,7 @@ Forwards Server B service ports to `localhost`. Press **Ctrl+C** to close.
 | `5174` | TRS (Rule Studio) frontend |
 | `3090` | CMS (Case Management) backend |
 | `5175` | CMS (Case Management) frontend |
+| `18866` | Voila (CMS notebook server) |
 | `8081` | Flowable REST |
 | `5984` | CouchDB |
 | `9200` | OpenSearch |
@@ -2145,6 +2146,7 @@ modification. Proceed to Phase F to validate.
 | 5174 | TRS Frontend |
 | 3090 | CMS Backend |
 | 5175 | CMS Frontend |
+| 18866 | Voila (CMS notebook server) |
 | 9200 | OpenSearch |
 | 15433 | PostgreSQL (extensions) |
 | 5051 | pgAdmin (extensions DB) |
@@ -3250,6 +3252,7 @@ docker compose -p tazama-core \
 | 5173 | TCS Frontend | ALB | `tcs` |
 | 5174 | TRS Frontend | ALB | `trs` |
 | 5175 | CMS Frontend | ALB | `cms` |
+| 18866 | Voila notebook server | Operator (EICE tunnel only) | - |
 | 9200 | OpenSearch | (NiFi ETL - pending confirmation) | - |
 | 12222 | SFTP | File ingest | - |
 | 15433 | PostgreSQL (CMS) | Server C NiFi ETL | - |

--- a/infra/aws/aws-deployment-instructions.md
+++ b/infra/aws/aws-deployment-instructions.md
@@ -217,7 +217,7 @@ Three private EC2 instances sit behind an Application Load Balancer. No instance
     │  keycloak:8080 │  │ trs-api:3005 │  │ dlh-api    :8282│
     │  hasura  :6100 │  │ cms    :5175 │  │ solr       :8983│
     │  pgadmin :5050 │  │ cms-api:3090 │  │ ozone-scm  :9876│
-    │  nats    :14222│  │ voila :18866 │  │ ozone-s3g  :9878│
+    │  nats    :14222│  │ pgadmin:5051 │  │ ozone-s3g  :9878│
     │  postgres:15432│  │ postgres:15433  │ ozone-recon:9888│
     │  valkey  :16379│  │ opensrch:9200│  └────────┬────────┘
     └────────────────┘  └──────┬───────┘           │

--- a/infra/aws/end-to-end-service-flow.md
+++ b/infra/aws/end-to-end-service-flow.md
@@ -51,6 +51,7 @@ flowchart TD
         TRSbe["TRS Backend :3005"]
         CMSfe["CMS Frontend :5175"]
         CMSbe["CMS Backend :3090"]
+        Voila["Voila :18866"]
         PGB["pgAdmin-ext :5051"]
         PG_B[("PostgreSQL\n:5432 / ext :15433")]
         OS[("OpenSearch :9200")]
@@ -495,6 +496,7 @@ corresponding Security Group ingress rules to be in place.
 
 | Server | Port | Service |
 |---|---|---|
+| Server B | 18866 | Voila (CMS notebook server) |
 | Server C | 8983 | Solr UI |
 | Server C | 9876 | Ozone SCM |
 | Server C | 9878 | Ozone S3G |

--- a/infra/aws/scripts/tunnel-server-b.ps1
+++ b/infra/aws/scripts/tunnel-server-b.ps1
@@ -33,6 +33,7 @@ Write-Host '  3005  -> TRS (Rule Studio) backend'
 Write-Host '  5174  -> TRS (Rule Studio) frontend'
 Write-Host '  3090  -> CMS (Case Management) backend'
 Write-Host '  5175  -> CMS (Case Management) frontend'
+Write-Host '  18866 -> Voila (CMS notebook server)'
 Write-Host '  8081  -> Flowable REST'
 Write-Host '  5984  -> CouchDB'
 Write-Host '  9200  -> OpenSearch'
@@ -65,6 +66,7 @@ try {
         -L 5174:localhost:5174 `
         -L 3090:localhost:3090 `
         -L 5175:localhost:5175 `
+        -L 18866:localhost:18866 `
         -L 8081:localhost:8081 `
         -L 5984:localhost:5984 `
         -L 9200:localhost:9200 `


### PR DESCRIPTION
## Summary

Follow-up to #175. Documents the Voila notebook server service added in the previous PR across all relevant documentation files.

## Changes

**`extensions/README.md`**
- Section 5.3 service table: add Voila row (`tazama-cms-voila`, port 18866)
- Section 6 (Accessing deployed components): add Voila URL under CMS

**`README.md`**
- Server B services list: add Voila notebook server (port 18866)

**`infra/aws/end-to-end-service-flow.md`**
- Mermaid Server B subgraph: add `Voila["Voila :18866"]` node
- Operator-only table: add Server B / 18866 / Voila row (internal Docker network + SSH tunnel only, no ALB)

**`infra/aws/aws-deployment-instructions.md`**
- Architecture ASCII diagram: add `voila :18866` to Server B box
- Script catalog port table for `tunnel-server-b.ps1`: add port 18866
- Phase E.1 port map Server B: add port 18866
- Reference port map Server B: add port 18866 (Operator / EICE tunnel only)

**`infra/aws/scripts/tunnel-server-b.ps1`**
- Add `18866 -> Voila (CMS notebook server)` to the displayed port list
- Add `-L 18866:localhost:18866` to the SSH port-forward flags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated service documentation to include Voila notebook server as a Server B extension, accessible on port 18866.
  * Added Voila to the service inventory and post-deployment URL references.
  * Updated deployment and tunneling instructions to expose the Voila notebook server for operator access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->