### PR TITLE
fix(cms): expose Voila on ALB and wire VITE_VOILA_BASE_URL to cms-frontend

### DIFF
--- a/extensions/docker-compose.dev.extensions.yaml
+++ b/extensions/docker-compose.dev.extensions.yaml
@@ -112,6 +112,7 @@ services:
       - .env
     environment:
       - VITE_API_BASE_URL=http://${SERVER_B_HOST}:${CMS_BACKEND_PORT}
+      - VITE_VOILA_BASE_URL=${VOILA_URL:-http://${SERVER_B_HOST}:${VOILA_PORT}}
       - VITE_ALLOWED_HOSTS=all
     ports:
       - "${CMS_FRONTEND_PORT}:5175"

--- a/extensions/docker-compose.hub.extensions.yaml
+++ b/extensions/docker-compose.hub.extensions.yaml
@@ -95,6 +95,7 @@ services:
       - .env
     environment:
       - VITE_API_BASE_URL=${CMS_API_URL:-http://${SERVER_B_HOST}:${CMS_BACKEND_PORT}}
+      - VITE_VOILA_BASE_URL=${VOILA_URL:-http://${SERVER_B_HOST}:${VOILA_PORT}}
       - VITE_ALLOWED_HOSTS=all
     ports:
       - "${CMS_FRONTEND_PORT}:5175"

--- a/infra/aws/aws-deployment-instructions.md
+++ b/infra/aws/aws-deployment-instructions.md
@@ -2886,6 +2886,7 @@ See A.6. OpenSearch is currently running with `DISABLE_SECURITY_PLUGIN=true`. Th
 | ALB Keycloak authentication on listeners | ✅ Done | - |
 | PostgreSQL passwords rotated | ❌ Default (`unused`) | G.2 - rotate and store in SSM |
 | NiFi login enforced | ❌ HTTP, no auth | G.2 - enable HTTPS, set password |
+| Voila notebook server auth | ❌ Public, no auth | G.4 - place behind Keycloak/OIDC proxy or restrict ALB ingress CIDR to VPN/office IPs |
 | Ozone S3G credentials rotated | ❌ Default (`tazama`/`tazama`) | G.2 - rotate key/secret |
 | OpenSearch security plugin enabled | ❌ Disabled | G.3 - re-enable, set password |
 | Keycloak admin password rotated | ❌ Default | A.7 - pass `-Password` at deploy |

--- a/infra/aws/aws-deployment-instructions.md
+++ b/infra/aws/aws-deployment-instructions.md
@@ -183,46 +183,48 @@ Three private EC2 instances sit behind an Application Load Balancer. No instance
      └──────────────────────────┘
 
      ┌──────────────────────────────────────────────────────────────┐
-     │  Application Load Balancer  (public subnet, ap-south-1)     │
-     │  HTTP - port-based routing (HTTPS + host-based: Phase E.3)  │
-     │  :5000  → Server A  tms-service                             │
-     │  :5100  → Server A  admin-service                           │
-     │  :3020  → Server A  auth-service                            │
-     │  :8080  → Server A  keycloak                                │
-     │  :5050  → Server A  pgAdmin (core)                          │
-     │  :6100  → Server A  hasura                                  │
-     │  :5173  → Server B  tcs-frontend                            │
-     │  :3010  → Server B  tcs-api                                 │
-     │  :5174  → Server B  trs-frontend                            │
-     │  :3005  → Server B  trs-api                                 │
-     │  :5175  → Server B  cms-frontend                            │
-     │  :3090  → Server B  cms-api                                 │
-     │  :5051  → Server B  pgAdmin (extensions)                    │
-     │  :8088  → Server C  nifi                                    │
-     │  :8000  → Server C  jupyterhub                              │
-     │  :7619  → Server C  auto-orchestrator                       │
-     │  :8282  → Server C  datalakehouse-api                       │
+     │  Application Load Balancer  (public subnet, ap-south-1)      │
+     │  HTTP - port-based routing (HTTPS + host-based: Phase E.3)   │
+     │  :5000  → Server A  tms-service                              │
+     │  :5100  → Server A  admin-service                            │
+     │  :3020  → Server A  auth-service                             │
+     │  :8080  → Server A  keycloak                                 │
+     │  :5050  → Server A  pgAdmin (core)                           │
+     │  :6100  → Server A  hasura                                   │
+     │  :5173  → Server B  tcs-frontend                             │
+     │  :3010  → Server B  tcs-api                                  │
+     │  :5174  → Server B  trs-frontend                             │
+     │  :3005  → Server B  trs-api                                  │
+     │  :5175  → Server B  cms-frontend                             │
+     │  :3090  → Server B  cms-api                                  │
+     │  :18866 → Server B  voila                                    │
+     │  :5051  → Server B  pgAdmin (extensions)                     │
+     │  :8088  → Server C  nifi                                     │
+     │  :8000  → Server C  jupyterhub                               │
+     │  :7619  → Server C  auto-orchestrator                        │
+     │  :8282  → Server C  datalakehouse-api                        │
      └──────────────────────────┬───────────────────────────────────┘
                                 │  VPC-internal routing (private IPs)
-              ┌─────────────────┼──────────────────┐
-              │                 │                  │
-    ┌─────────▼──────┐  ┌───────▼──────┐  ┌────────▼────────┐
-    │   server-a     │  │   server-b   │  │   server-c      │
-    │   tazama-core  │  │  extensions  │  │   biar          │
-    │   10.0.1.10    │  │  10.0.1.20   │  │   10.0.1.30     │
-    │                │  │              │  │                  │
-    │  tms     :5000 │  │ tcs    :5173 │  │ nifi       :8088│
-    │  admin   :5100 │  │ tcs-api:3010 │  │ jupyterhub :8000│
-    │  auth    :3020 │  │ trs    :5174 │  │ auto-orch  :7619│
-    │  keycloak:8080 │  │ trs-api:3005 │  │ dlh-api    :8282│
-    │  hasura  :6100 │  │ cms    :5175 │  │ solr       :8983│
-    │  pgadmin :5050 │  │ cms-api:3090 │  │ ozone-scm  :9876│
-    │  nats    :14222│  │ pgadmin:5051 │  │ ozone-s3g  :9878│
-    │  postgres:15432│  │ postgres:15433  │ ozone-recon:9888│
-    │  valkey  :16379│  │ opensrch:9200│  └────────┬────────┘
-    └────────────────┘  └──────┬───────┘           │
-           ▲  ▲  ▲             │    direct :8282    │
-           │  │  │             └────────────────────┘
+              ┌─────────────────┼────────────────────┐
+              │                 │                    │
+    ┌─────────▼──────┐  ┌───────▼────────┐  ┌────────▼────────┐
+    │   server-a     │  │   server-b     │  │   server-c      │
+    │   tazama-core  │  │  extensions    │  │   biar          │
+    │   10.0.1.10    │  │  10.0.1.20     │  │   10.0.1.30     │
+    │                │  │                │  │                 │
+    │  tms     :5000 │  │ tcs    :5173   │  │ nifi       :8088│
+    │  admin   :5100 │  │ tcs-api:3010   │  │ jupyterhub :8000│
+    │  auth    :3020 │  │ trs    :5174   │  │ auto-orch  :7619│
+    │  keycloak:8080 │  │ trs-api:3005   │  │ dlh-api    :8282│
+    │  hasura  :6100 │  │ cms    :5175   │  │ solr       :8983│
+    │  pgadmin :5050 │  │ cms-api:3090   │  │ ozone-scm  :9876│
+    │  nats    :14222│  │ pgadmin:5051   │  │ ozone-s3g  :9878│
+    │  postgres:15432│  │ postgres:15433 │  │ ozone-recon:9888│
+    │  valkey  :16379│  │ opensrch:9200  │  └────────┬────────┘
+    └────────────────┘  │ voila  :18866  │           │
+                        └──────┬─────────┘           │
+           ▲  ▲  ▲             │    direct :8282     │
+           │  │  │             └─────────────────────┘
            │  │  │    (CMS backend → datalakehouse-api, bypasses ALB)
            │  │  │
            │  └── cross-server (NATS :14222, auth :3020, postgres :15432)
@@ -1124,6 +1126,7 @@ Four security groups. EC2 instances have **no internet-facing inbound rules** - 
 | Inbound | 6100 | TCP | `0.0.0.0/0` | Hasura |
 | Inbound | 3005–3090 | TCP | `0.0.0.0/0` | TRS / TCS / CMS backends |
 | Inbound | 5173–5175 | TCP | `0.0.0.0/0` | TCS / TRS / CMS frontends |
+| Inbound | 18866 | TCP | `0.0.0.0/0` | Voila (CMS notebook server) |
 | Inbound | 8088 | TCP | `0.0.0.0/0` | NiFi UI |
 | Outbound | All | All | `0.0.0.0/0` | Routing to EC2 target groups |
 
@@ -1149,6 +1152,7 @@ Four security groups. EC2 instances have **no internet-facing inbound rules** - 
 |---|---|---|---|---|
 | Inbound | 3005–3090 | TCP | sg-tazama-alb | TRS / TCS / CMS backends |
 | Inbound | 5173–5175 | TCP | sg-tazama-alb | TCS / TRS / CMS frontends |
+| Inbound | 18866 | TCP | sg-tazama-alb | Voila (CMS notebook server) |
 | Inbound | 5051 | TCP | sg-tazama-alb | pgAdmin (extensions) |
 | Inbound | 0–65535 | TCP | `10.0.1.0/24` | Cross-server (OpenSearch :9200, PostgreSQL :15433, etc.) |
 | Inbound | 22 | TCP | sg-tazama-eice | SSH via EICE endpoint only |
@@ -2185,7 +2189,7 @@ tofu apply -var-file terraform.tfvars -var-file alb.tfvars
 
 OpenTofu plans and applies only the ALB delta. The EC2 instances and all
 running containers are untouched. Expected additions: roughly `+30 resources`
-(1 ALB, 14 target groups, 14 port-based HTTP listeners, security group rules).
+(1 ALB, 15 target groups, 15 port-based HTTP listeners, security group rules).
 
 > [!WARNING]
 > **Once `domain.tfvars` has been applied (Phase E.3), always include it in every subsequent `tofu apply`.** Omitting it tells OpenTofu to remove `module.dns_public`, which destroys the Route 53 public zone and all its records. If that has already happened, use the full three-file command for all future applies:
@@ -3252,7 +3256,7 @@ docker compose -p tazama-core \
 | 5173 | TCS Frontend | ALB | `tcs` |
 | 5174 | TRS Frontend | ALB | `trs` |
 | 5175 | CMS Frontend | ALB | `cms` |
-| 18866 | Voila notebook server | Operator (EICE tunnel only) | - |
+| 18866 | Voila notebook server | ALB | `voila` |
 | 9200 | OpenSearch | (NiFi ETL - pending confirmation) | - |
 | 12222 | SFTP | File ingest | - |
 | 15433 | PostgreSQL (CMS) | Server C NiFi ETL | - |

--- a/infra/aws/modules/alb/main.tf
+++ b/infra/aws/modules/alb/main.tf
@@ -35,6 +35,7 @@ locals {
     trs-api      = { port = 3005, server = "b" }
     cms-frontend = { port = 5175, server = "b" }
     cms-api      = { port = 3090, server = "b" }
+    voila        = { port = 18866, server = "b" }
     pgadmin-ext           = { port = 5051, server = "b" }
     nifi                    = { port = 8088, server = "c" }
     jupyterhub              = { port = 8000, server = "c" }
@@ -60,6 +61,7 @@ locals {
     cms-api     = "/api/docs"
     trs-api     = "/api/docs"
     tcs-api     = "/api/docs"
+    voila       = "/voila/"
   }
 }
 

--- a/infra/aws/modules/dns-public/main.tf
+++ b/infra/aws/modules/dns-public/main.tf
@@ -86,6 +86,7 @@ locals {
     trs-api                 = var.target_group_arns["trs-api"]
     cms                     = var.target_group_arns["cms-frontend"]
     cms-api                 = var.target_group_arns["cms-api"]
+    voila                   = var.target_group_arns["voila"]
     pgadmin-ext             = var.target_group_arns["pgadmin-ext"]
     nifi                    = var.target_group_arns["nifi"]
     jupyter                 = var.target_group_arns["jupyterhub"]
@@ -116,6 +117,7 @@ locals {
     jupyter                 = 19
     deapi                   = 20
     dems                    = 21
+    voila                   = 22
   }
 }
 

--- a/infra/aws/modules/security-groups/main.tf
+++ b/infra/aws/modules/security-groups/main.tf
@@ -95,6 +95,14 @@ resource "aws_security_group" "alb" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  ingress {
+    description = "Voila (CMS notebook server)"
+    from_port   = 18866
+    to_port     = 18866
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   # Server C service ports
   ingress {
     description = "NiFi UI"
@@ -218,6 +226,14 @@ resource "aws_security_group" "server_b" {
     description     = "TCS / TRS / CMS frontends (Vite dev ports)"
     from_port       = 5173
     to_port         = 5175
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  ingress {
+    description     = "Voila (CMS notebook server)"
+    from_port       = 18866
+    to_port         = 18866
     protocol        = "tcp"
     security_groups = [aws_security_group.alb.id]
   }

--- a/infra/aws/scripts/helpers.ps1
+++ b/infra/aws/scripts/helpers.ps1
@@ -144,15 +144,21 @@ function Set-RemoteEnvOverlay {
     $lines = Get-Content $OverlayFile |
              Where-Object { $_ -notmatch '^\s*#' -and $_ -match '=' }
 
-    foreach ($line in $lines) {
+    if (-not $lines) { return }
+
+    # Build all sed/append commands as a single bash script and run them in one
+    # SSH connection. Opening one EICE tunnel per key causes rate-limit hangs
+    # when the overlay has many entries.
+    $bashLines = foreach ($line in $lines) {
         $key   = ($line -split '=', 2)[0].Trim()
         $value = ($line -split '=', 2)[1].Trim()
-        # The sed uses | as a delimiter to tolerate dots in values (DNS names).
-        $sedCmd = "grep -q '^${key}=' ${RemoteEnvFile} && " +
-                  "sed -i 's|^${key}=.*|${key}=${value}|' ${RemoteEnvFile} || " +
-                  "echo '${key}=${value}' >> ${RemoteEnvFile}"
-        Invoke-RemoteCommand $InstanceId $sedCmd
+        # Use | as sed delimiter to tolerate dots and slashes in values.
+        "grep -q '^${key}=' ${RemoteEnvFile} && " +
+        "sed -i 's|^${key}=.*|${key}=${value}|' ${RemoteEnvFile} || " +
+        "echo '${key}=${value}' >> ${RemoteEnvFile}"
     }
+    $batchCmd = $bashLines -join '; '
+    Invoke-RemoteCommand $InstanceId $batchCmd
 }
 
 # -- Wait-Bootstrap ------------------------------------------------------------

--- a/infra/aws/scripts/helpers.ps1
+++ b/infra/aws/scripts/helpers.ps1
@@ -149,13 +149,23 @@ function Set-RemoteEnvOverlay {
     # Build all sed/append commands as a single bash script and run them in one
     # SSH connection. Opening one EICE tunnel per key causes rate-limit hangs
     # when the overlay has many entries.
+    #
+    # Security: values may contain single quotes (passwords), pipe characters
+    # (URLs), or other shell metacharacters. Mitigations applied:
+    #   1. POSIX-escape values: replace every ' with '\'' before inlining.
+    #   2. Use a control character (\x01) as the sed delimiter so | in values
+    #      cannot break the sed expression.
+    #   3. Use an explicit if/then/else instead of "&& ... ||" so a sed failure
+    #      does not trigger the append branch and create duplicate KEY= lines.
     $bashLines = foreach ($line in $lines) {
         $key   = ($line -split '=', 2)[0].Trim()
         $value = ($line -split '=', 2)[1].Trim()
-        # Use | as sed delimiter to tolerate dots and slashes in values.
-        "grep -q '^${key}=' ${RemoteEnvFile} && " +
-        "sed -i 's|^${key}=.*|${key}=${value}|' ${RemoteEnvFile} || " +
-        "echo '${key}=${value}' >> ${RemoteEnvFile}"
+        # Escape single quotes for POSIX shell: ' -> '\''.
+        $vEsc  = $value -replace "'", "'\''" 
+        # \x01 is used as the sed delimiter; it cannot appear in env values.
+        "if grep -q '^${key}=' ${RemoteEnvFile}; then " +
+        "sed -i 's`u{1}^${key}=.*`u{1}${key}=${vEsc}`u{1}' ${RemoteEnvFile}; " +
+        "else printf '%s\n' '${key}=${vEsc}' >> ${RemoteEnvFile}; fi"
     }
     $batchCmd = $bashLines -join '; '
     Invoke-RemoteCommand $InstanceId $batchCmd

--- a/infra/aws/templates/env-extensions.tpl
+++ b/infra/aws/templates/env-extensions.tpl
@@ -22,6 +22,7 @@ ADMIN_SERVICE_URL=http://core.tazama.internal:5100
 TRS_API_URL=https://trs-api.beta.tazama.org
 TCS_API_URL=https://tcs-api.beta.tazama.org
 CMS_API_URL=https://cms-api.beta.tazama.org
+VOILA_URL=https://voila.beta.tazama.org
 SIMULATION_ENDPOINT=https://tms.beta.tazama.org/v1/evaluate/iso20022/pacs.002.001.12
 ADMIN_ENDPOINT=https://admin.beta.tazama.org
 


### PR DESCRIPTION
## Problem

The CMS frontend embeds Voila notebooks in an `<iframe>`. The iframe `src` is resolved by the **user's browser**, not the CMS server, so Voila must be reachable from the browser - not just from within the Docker network.

Two issues prevented this from working:

1. `VITE_VOILA_BASE_URL` was never passed to the `cms-frontend` container, so `VoilaFrame.tsx` always rendered the "Visualization Unavailable" warning.
2. Even with the env var set, the fallback URL used `extensions.tazama.internal` (a VPC-private DNS name) which browsers accessing via the ALB cannot resolve. Voila needed its own ALB target group.

## Changes

### Compose files
- `extensions/docker-compose.hub.extensions.yaml` - Add `VITE_VOILA_BASE_URL` to `cms-frontend` environment, using `${VOILA_URL:-http://${SERVER_B_HOST}:${VOILA_PORT}}`. For AWS deployments, `VOILA_URL` is set to the public HTTPS subdomain by `env-extensions.tpl`; the fallback covers local and tunnel use.
- `extensions/docker-compose.dev.extensions.yaml` - Same change for source-build deployments.

### Terraform / OpenTofu
- `infra/aws/modules/alb/main.tf` - Add `voila = { port = 18866, server = "b" }` to the services locals, with `/voila/` as the health check path.
- `infra/aws/modules/security-groups/main.tf` - Add port `18866` ingress rule to the ALB SG (from `0.0.0.0/0`) and to the Server B SG (from the ALB SG).
- `infra/aws/modules/dns-public/main.tf` - Add `voila` to `subdomain_map` and `priority_map` (priority 22), creating the `voila.beta.tazama.org` Route 53 alias record and HTTPS listener rule.

### Deployment config
- `infra/aws/templates/env-extensions.tpl` - Add `VOILA_URL=https://voila.beta.tazama.org`, patched into Server B `.env` at deploy time.

### Documentation
- `infra/aws/aws-deployment-instructions.md` - Update ALB architecture diagram, ALB SG table, Server B SG table, resource count (14 → 15 TGs/listeners), and Server B exterior ports table.

## Deployment

After merging, re-run on Server B:
```powershell
tofu apply -var-file terraform.tfvars -var-file alb.tfvars   # adds 5 resources, changes 2 SG rules
docker compose ... up -d --force-recreate cms-frontend        # picks up VITE_VOILA_BASE_URL
```

Expected plan: **5 to add, 2 to change, 0 to destroy.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Voila service is now publicly exposed via application load balancer with a dedicated subdomain endpoint.
  * Added security group rules to permit traffic to the Voila service port.
  * Extended frontend configuration to support targeting the Voila service endpoint.

* **Documentation**
  * Updated AWS deployment instructions to reflect Voila's public availability through the load balancer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->