### PR TITLE
fix: add CMS_FRONTEND_ORIGIN + VOILA_URL overrides and split restart-service pull switches

### DIFF
--- a/extensions/env/cms.env
+++ b/extensions/env/cms.env
@@ -78,6 +78,7 @@ COUCHDB_PASSWORD=1234
 
 # Visualization and Lakehouse
 VOILA_URL=http://tazama-cms-voila:8866
+CMS_FRONTEND_ORIGIN=http://localhost:5175
 GOLD_LAKEHOUSE_API_URL=http://${SERVER_C_HOST}:8282
 GOLD_LAKEHOUSE_TIMEOUT=120000
 
@@ -94,4 +95,3 @@ OPENSEARCH_REFRESH=true
 VITE_APP_NAME="Tazama Case Management System"
 VITE_APP_VERSION=0.0.1
 VITE_CRYPTO_KEY=rCRrt08XYmYZrUoKffOQWXa327AJyBxv
-VOILA_URL=http://tazama-cms-voila:8866

--- a/infra/aws/aws-deployment-instructions.md
+++ b/infra/aws/aws-deployment-instructions.md
@@ -1701,7 +1701,7 @@ scripts dot-source `helpers.ps1` for shared functions and constants.
 | [`deploy-extensions.ps1`](#deploy-extensionsps1) | Server A (DEMS/DEAPI) + Server B - tazama-extensions stack |
 | [`deploy-biar.ps1`](#deploy-biarps1) | Server C - tazama-biar stack |
 | [`deploy-lakehouse.ps1`](#deploy-lakehouseps1) | Server C - stage and unpack Lakehouse warehouse data via S3 |
-| [`restart-service.ps1`](#restart-serviceps1) | Pull latest image and recreate a single service on any server |
+| [`restart-service.ps1`](#restart-serviceps1) | Pull latest repo/image and recreate a single service on any server |
 | [`teardown.ps1`](#teardownps1) | Stop all stacks across all three servers |
 | [`add-ssh-key.ps1`](#add-ssh-keyps1) | Add an SSH public key to one or more servers |
 | [`tunnel-all.ps1`](#tunnel-allps1) | Open port-forward tunnels to all three servers simultaneously |
@@ -1877,20 +1877,20 @@ on the state bucket; the EC2 instance role must have `s3:GetObject` on the
 
 [infra/aws/scripts/restart-service.ps1](full-stack-docker-tazama/infra/aws/scripts/restart-service.ps1)
 
-Pulls the latest image for a single Docker Compose service and recreates its
-container without touching any other running containers.
+Pulls the latest repo changes and image for a single Docker Compose service
+and recreates its container without touching any other running containers.
 
 The script reads the running container's `com.docker.compose` labels to
 discover the exact working directory and compose file chain used to start it,
-then issues a targeted `docker compose up --no-deps --force-recreate`.  This
-means the command is always reconstructed from live state - no hardcoded file
-chains that can go stale.
+then runs `git pull` in that directory followed by a targeted
+`docker compose up --no-deps --force-recreate`.  This means the command is
+always reconstructed from live state - no hardcoded file chains that can go stale.
 
 Server A's two sub-chains (`tazama-core` main stack and extensions APIs) are
 handled transparently by this label-based approach.
 
 ```powershell
-# Update admin-service on Server A
+# Update admin-service on Server A (pulls repo + image)
 .\restart-service.ps1 -Server A -Service admin-service
 
 # Update deapi (extensions API running on Server A)
@@ -1902,15 +1902,22 @@ handled transparently by this label-based approach.
 # Update NiFi on Server C
 .\restart-service.ps1 -Server C -Service nifi
 
-# Force recreate without pulling (e.g. env change only)
+# Apply a repo change (e.g. updated env file) without pulling a new image
 .\restart-service.ps1 -Server C -Service automation-orchestrator -NoPull
+
+# Pull a new image without applying pending repo changes
+.\restart-service.ps1 -Server B -Service cms-frontend -NoRepoPull
+
+# Force recreate only - skip both pulls (e.g. restart a crashed container)
+.\restart-service.ps1 -Server B -Service cms-frontend -NoPull -NoRepoPull
 ```
 
 | Parameter | Description |
 |---|---|
 | `-Server` | **Required.** `A`, `B`, or `C`. |
 | `-Service` | **Required.** Docker Compose service name (e.g. `rule-001`, `tcs-api`, `nifi`). |
-| `-NoPull` | Skip the image pull; only recreate the container (useful for env/config-only changes). |
+| `-NoPull` | Skip the DockerHub image pull (`--pull always`). Use when the image is already current. |
+| `-NoRepoPull` | Skip the `git pull` of the full-stack-docker-tazama repo on the target server. Use when you want to apply an image update without pulling pending repo changes. |
 
 After recreating, the script prints a `docker ps` table confirming the
 container name, status, and image digest.

--- a/infra/aws/aws-deployment-instructions.md
+++ b/infra/aws/aws-deployment-instructions.md
@@ -1286,6 +1286,8 @@ Files created:
 | `TRS_API_URL` / `TCS_API_URL` / `CMS_API_URL` | localhost defaults | Public ALB subdomains | Browser-facing VITE_ vars |
 | `SIMULATION_ENDPOINT` / `ADMIN_ENDPOINT` | localhost defaults | Public ALB subdomains | Browser-facing VITE_ vars |
 | `ALLOWED_ORIGINS` / `CORS_ORIGINS` | localhost | Public ALB subdomains | CORS |
+| `VOILA_URL` | `http://tazama-cms-voila:8866` (container-internal) | `https://voila.beta.tazama.org` | Prevents mixed-content block when CMS frontend embeds the Voila iframe over HTTPS |
+| `CMS_FRONTEND_ORIGIN` | `http://localhost:5175` | `https://cms.beta.tazama.org` | Sets the Voila `frame-ancestors` CSP to allow the CMS frontend to embed the iframe (requires CMS image with env-var-driven CSP support - see [case-management-system #92](https://github.com/tazama-lf/case-management-system/issues/92)) |
 | `GOLD_LAKEHOUSE_API_URL` | `http://${SERVER_C_HOST}:8282` (placeholder, resolves to dev default at runtime) | `SERVER_C_HOST=biar.tazama.internal` set by this overlay | Server C datalakehouse-api |
 
 ---
@@ -2894,6 +2896,7 @@ See A.6. OpenSearch is currently running with `DISABLE_SECURITY_PLUGIN=true`. Th
 | PostgreSQL passwords rotated | ❌ Default (`unused`) | G.2 - rotate and store in SSM |
 | NiFi login enforced | ❌ HTTP, no auth | G.2 - enable HTTPS, set password |
 | Voila notebook server auth | ❌ Public, no auth | G.4 - place behind Keycloak/OIDC proxy or restrict ALB ingress CIDR to VPN/office IPs |
+| Voila iframe CSP + mixed content | ⏳ Fix in PR #180 | Pending CMS image update ([case-management-system #92](https://github.com/tazama-lf/case-management-system/issues/92)) - env vars staged in `env-extensions.tpl` |
 | Ozone S3G credentials rotated | ❌ Default (`tazama`/`tazama`) | G.2 - rotate key/secret |
 | OpenSearch security plugin enabled | ❌ Disabled | G.3 - re-enable, set password |
 | Keycloak admin password rotated | ❌ Default | A.7 - pass `-Password` at deploy |

--- a/infra/aws/scripts/restart-service.ps1
+++ b/infra/aws/scripts/restart-service.ps1
@@ -31,8 +31,14 @@
     "tcs-api", "nifi", "automation-orchestrator").
 
 .PARAMETER NoPull
-    Skip the image pull step.  Useful when the latest image is already
+    Skip the DockerHub image pull step.  Useful when the latest image is already
     present on the host and you only want to force a config/env recreate.
+
+.PARAMETER NoRepoPull
+    Skip the 'git pull' of the full-stack-docker-tazama repo on the target
+    server before recreating the container.  Useful when you want to pull a
+    fresh image without applying any pending repo changes, or when the working
+    directory is not a git repo.
 
 .EXAMPLE
     .\restart-service.ps1 -Server A -Service rule-001
@@ -40,6 +46,8 @@
     .\restart-service.ps1 -Server B -Service tcs-api
     .\restart-service.ps1 -Server C -Service nifi
     .\restart-service.ps1 -Server C -Service automation-orchestrator -NoPull
+    .\restart-service.ps1 -Server B -Service cms-frontend -NoRepoPull
+    .\restart-service.ps1 -Server B -Service cms-frontend -NoPull -NoRepoPull
 #>
 
 [CmdletBinding()]
@@ -51,7 +59,9 @@ param(
     [Parameter(Mandatory)]
     [string]$Service,
 
-    [switch]$NoPull
+    [switch]$NoPull,
+
+    [switch]$NoRepoPull
 )
 
 . "$PSScriptRoot\helpers.ps1"
@@ -71,7 +81,8 @@ Write-Host ''
 Write-Host "=== Restart service: $Service on $label ===" -ForegroundColor Cyan
 Write-Host "[$label] Project : $project"
 Write-Host "[$label] Service : $Service"
-Write-Host "[$label] Pull    : $(-not $NoPull)"
+Write-Host "[$label] Pull    : $(-not $NoPull) (DockerHub image)"
+Write-Host "[$label] RepoPull: $(-not $NoRepoPull) (full-stack git pull)"
 Write-Host ''
 
 # -- Discover compose context from the running container's labels ----------------------------
@@ -127,6 +138,12 @@ Write-Host "[$label] Working dir: $workingDir"
 
 # Convert comma-separated absolute paths to '-f <path>' flags
 $fFlags = ($configFiles -split ',' | ForEach-Object { "-f $_" }) -join ' '
+
+# -- Repo pull ------------------------------------------------------------------------------
+if (-not $NoRepoPull) {
+    Write-Host "[$label] Pulling latest full-stack repo in $workingDir..."
+    Invoke-RemoteCommand -InstanceId $instanceId -Command "cd $workingDir && git pull"
+}
 
 # -- Recreate -------------------------------------------------------------------------------
 $composeCmd = (

--- a/infra/aws/templates/env-extensions.tpl
+++ b/infra/aws/templates/env-extensions.tpl
@@ -23,6 +23,7 @@ TRS_API_URL=https://trs-api.beta.tazama.org
 TCS_API_URL=https://tcs-api.beta.tazama.org
 CMS_API_URL=https://cms-api.beta.tazama.org
 VOILA_URL=https://voila.beta.tazama.org
+CMS_FRONTEND_ORIGIN=https://cms.beta.tazama.org
 SIMULATION_ENDPOINT=https://tms.beta.tazama.org/v1/evaluate/iso20022/pacs.002.001.12
 ADMIN_ENDPOINT=https://admin.beta.tazama.org
 


### PR DESCRIPTION
## Summary

Three independent fixes bundled together as they all relate to the Voila/CMS deployment work on AWS.

---

### 1. CMS env var overrides for AWS (relates to #179)

**`infra/aws/templates/env-extensions.tpl`**
- Added `CMS_FRONTEND_ORIGIN=https://cms.beta.tazama.org` - overrides the frame-ancestors CSP origin so the Voila iframe is accepted by the browser when embedded in the CMS frontend at `https://cms.beta.tazama.org`

**`extensions/env/cms.env`**
- Added `CMS_FRONTEND_ORIGIN=http://localhost:5175` local dev default
- Removed duplicate `VOILA_URL` line at end of file (was already set correctly in the Visualization section)

Note: `VOILA_URL=https://voila.beta.tazama.org` was already present in the template from a previous change. The `CMS_FRONTEND_ORIGIN` change is staged ahead of the CMS team shipping the fix in [case-management-system #92](https://github.com/tazama-lf/case-management-system/issues/92).

---

### 2. Split `-NoPull` switch in `restart-service.ps1`

Previously `-NoPull` was the only switch, ambiguously controlling both DockerHub image pulls and (implicitly) any future repo pulls. A `git pull` step has now been added to the script and controlled independently:

| Switch | Controls |
|---|---|
| `-NoPull` | DockerHub image pull (`--pull always` on `docker compose up`) |
| `-NoRepoPull` | `git pull` of the full-stack-docker-tazama repo on the target server |

Both default to `false` (both pulls happen). They can be combined freely.

**`infra/aws/aws-deployment-instructions.md`** updated to reflect the new switch and examples.

---

## Testing

- `restart-service.ps1` changes: can be tested immediately on any server
- `CMS_FRONTEND_ORIGIN` / `VOILA_URL`: takes effect on next `deploy.ps1` run or `restart-service.ps1 -Server B -Service cms-frontend` once the CMS team publishes the updated image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Service restart process now pulls latest repository changes before recreating containers
  * Introduced new deployment flag to independently control repository synchronization from Docker image pulls

* **Chores**
  * Added environment configuration for CMS frontend origin
  * Updated deployment documentation with enhanced script capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->