### PR TITLE
fix: OpenSearch tuning, bootstrap hardening, EC2 unlimited credits, and community-friendly scripts

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -213,7 +213,8 @@ These infrastructure services are started as part of the `tazama-extensions` Com
 | SFTP | `tazama-sftp-1` | 12222 | SFTP server for transaction file uploads (used by TCS) |
 | CouchDB | `tazama-cms-couchdb` | 5984 | Document database for CMS audit and case data |
 | Flowable | `tazama-cms-flowable` | 8081 | Workflow engine for CMS case lifecycle management |
-| OpenSearch | `opensearch-node1` | 9200 | Search and indexing for transaction and case data |
+| OpenSearch | `opensearch-node1` | 9200 | Audit log store for TCS, TRS, and CMS (forensic audit trail) |
+| OpenSearch init | `opensearch-init` | -- | One-shot container: applies audit index template (30s refresh, async translog, 0 replicas) on first start |
 | DB Migration | `cms-migrations` | -- | One-shot container: applies CMS schema to PostgreSQL on startup |
 | pgAdmin | `pgadmin` | 5051 | Optional PostgreSQL web UI (included if pgAdmin is selected) |
 

--- a/extensions/docker-compose.extensions.infrastructure.yaml
+++ b/extensions/docker-compose.extensions.infrastructure.yaml
@@ -68,6 +68,7 @@ services:
   opensearch-node1:
     image: opensearchproject/opensearch:2.13.0
     container_name: opensearch-node1
+    restart: always
     environment:
       - cluster.name=opensearch-cluster
       - node.name=opensearch-node1
@@ -75,6 +76,11 @@ services:
       - bootstrap.memory_lock=true
       - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
       - DISABLE_SECURITY_PLUGIN=true
+      # Reduce indexing memory buffer (default 10% of heap) - low write volume audit use case
+      - indices.memory.index_buffer_size=5%
+      # Single write thread is sufficient for sequential audit log writes
+      - thread_pool.write.size=1
+      - thread_pool.write.queue_size=500
     ulimits:
       memlock:
         soft: -1
@@ -92,6 +98,32 @@ services:
       timeout: 10s
       retries: 10
       start_period: 60s
+
+  # One-shot init container: applies index template and updates existing indices
+  # to use a slower refresh interval and async translog. Runs once per compose up,
+  # exits immediately after. Uses the already-pulled opensearch image to avoid
+  # pulling an additional image.
+  opensearch-init:
+    image: opensearchproject/opensearch:2.13.0
+    container_name: opensearch-init
+    restart: "no"
+    depends_on:
+      opensearch-node1:
+        condition: service_healthy
+    entrypoint: ["bash", "-c"]
+    command:
+      - |
+        # Apply index template for all future indices
+        curl -sf -X PUT "http://opensearch-node1:9200/_template/tazama-audit-defaults" \
+          -H "Content-Type: application/json" \
+          -d '{"index_patterns":["*"],"settings":{"refresh_interval":"30s","number_of_replicas":0,"translog.sync_interval":"30s","translog.durability":"async"}}' \
+          && echo "[opensearch-init] Index template applied."
+        # Apply to any existing indices (best-effort - may be empty on first run)
+        curl -sf -X PUT "http://opensearch-node1:9200/*/_settings" \
+          -H "Content-Type: application/json" \
+          -d '{"settings":{"refresh_interval":"30s","translog.sync_interval":"30s","translog.durability":"async"}}' \
+          && echo "[opensearch-init] Existing index settings updated." \
+          || echo "[opensearch-init] No user indices yet - template will apply on first write."
 
 volumes:
   sftp_data:

--- a/infra/aws/aws-deployment-instructions.md
+++ b/infra/aws/aws-deployment-instructions.md
@@ -1737,7 +1737,14 @@ Provides the following functions:
 | `Set-RemoteEnvOverlay` | Reads a `KEY=VALUE` overlay file and applies each entry to a remote `.env` file using `sed` (replaces existing keys, appends missing ones) |
 | `Wait-Bootstrap` | Polls an instance until the bootstrap script has written its completion marker (up to 15 min) |
 
-Constants defined at script scope (edit here to change region, profile, or branch):
+Constants defined at script scope. Three of them can be overridden without editing the file by setting environment variables before running any script:
+
+```powershell
+# Set once per shell session (or add to your $PROFILE)
+$env:TAZAMA_AWS_REGION  = 'eu-west-1'          # if deploying outside ap-south-1
+$env:TAZAMA_AWS_PROFILE = 'my-aws-profile'      # if your CLI profile is not named 'tazama'
+$env:TAZAMA_SSH_KEY     = "$HOME\.ssh\my_key"   # path to your EC2 SSH private key
+```
 
 | Constant | Default value | Override env var | Purpose |
 |---|---|---|---|

--- a/infra/aws/aws-deployment-instructions.md
+++ b/infra/aws/aws-deployment-instructions.md
@@ -93,6 +93,7 @@
   - [`tofu apply` fails with `AccessDeniedException: acm:RequestCertificate`](#tofu-apply-fails-with-accessdeniedexception-acmrequestcertificate)
   - [`tofu apply` fails with "Module not installed"](#tofu-apply-fails-with-module-not-installed)
   - [ALB health check returns "Blocked request. This host is not allowed."](#alb-health-check-returns-blocked-request-this-host-is-not-allowed)
+  - [Server B SSH hangs - t3 CPU credit exhaustion](#server-b-ssh-hangs---t3-cpu-credit-exhaustion)
   - [Accessing container logs on an EC2 instance](#accessing-container-logs-on-an-ec2-instance)
 - [Reference: Compose Chain Matrix (Server A)](#reference-compose-chain-matrix-server-a)
 - [Reference: Port Map](#reference-port-map)
@@ -1188,6 +1189,9 @@ A reusable module for one EC2 instance.  All three servers are created from it.
 Notable settings:
 - `private_ip` - fixed address; ensures DNS records are stable across stop/start
 - `root_block_device` - gp3, encrypted, `delete_on_termination = true`
+- `credit_specification { cpu_credits = "unlimited" }` - keeps t3 burst credits unlimited
+  so JVM workloads (OpenSearch, Flowable) never exhaust the credit pool and stall SSH/Docker.
+  Ignored by AWS for fixed-performance families (m5, r5, etc.) that do not use credits.
 - `metadata_options` - IMDSv2 required (`http_tokens = "required"`); prevents
   SSRF-based credential theft via the instance metadata endpoint
 - `iam_instance_profile` - grants the instance SSM read-only access (for the
@@ -1229,16 +1233,20 @@ is rendered by `templatefile()` in `main.tf` and passed as `user_data` to all
 three instances.
 
 It runs once at first boot and:
-1. Installs Docker CE from the Amazon Linux 2023 dnf repo
-2. Installs the Docker Compose v2 plugin from GitHub releases
-3. Clones the `tazama-lf/full-stack-docker-tazama` repo to
+1. Creates a 4 GB swap file (`/swapfile`) and adds it to `/etc/fstab` so the
+   kernel spills to disk before OOM-killing JVM containers (OpenSearch, Flowable)
+2. Writes `/etc/docker/daemon.json` with `json-file` log rotation (`50m × 3 files`)
+   before Docker is installed so all containers inherit the limit from first start
+3. Installs Docker CE from the Amazon Linux 2023 dnf repo
+4. Installs the Docker Compose v2 plugin from GitHub releases
+5. Clones the `tazama-lf/full-stack-docker-tazama` repo to
    `/home/ec2-user/full-stack-docker-tazama`
-4. Fetches `GH_TOKEN` from SSM Parameter Store (`/tazama/gh_token`) using
+6. Fetches `GH_TOKEN` from SSM Parameter Store (`/tazama/gh_token`) using
    the instance's IAM role - no credentials in user_data
-5. Writes `GH_TOKEN` to `/etc/environment` (available to all sessions)
-6. Logs in to `ghcr.io` and copies the Docker credential store to
+7. Writes `GH_TOKEN` to `/etc/environment` (available to all sessions)
+8. Logs in to `ghcr.io` and copies the Docker credential store to
    `/home/ec2-user/.docker/` so the ec2-user account can pull images
-7. Writes `/home/ec2-user/.bootstrap-complete` marker
+9. Writes `/home/ec2-user/.bootstrap-complete` marker
 
 **Template variables:**
 
@@ -1737,7 +1745,7 @@ Constants defined at script scope (edit here to change region, profile, or branc
 | `$Script:AwsProfile` | `tazama` | AWS CLI named profile |
 | `$Script:RemoteRepo` | `/home/ec2-user/full-stack-docker-tazama` | Repo path on all three servers |
 | `$Script:RepoBranch` | `dev` | Branch pulled on each server during deploy |
-| `$Script:KeyFile` | `infra/aws/tazama-aws.pem` | EC2 SSH private key (gitignored) |
+| `$Script:KeyFile` | `$env:USERPROFILE\.ssh\tazama_ed25519` | EC2 SSH private key (ed25519, in user SSH folder) |
 
 ---
 
@@ -3087,6 +3095,36 @@ server: {
 > **Note:** `allowedHosts: 'all'` is acceptable for a private developer sandbox. Do not use it in a production deployment - use the explicit hostname list or switch to the custom-domain HTTPS configuration (Phase G), which serves all services through a single domain that can be permanently whitelisted.
 
 > **Tip:** Backend services (those exposing a REST API) will not show this error. It only appears for services that embed a Vite dev server. Use a backend health endpoint to confirm ALB routing independently of the Vite issue.
+
+---
+
+### Server B SSH hangs - t3 CPU credit exhaustion
+
+**Symptom:** SSH to Server B hangs indefinitely at the banner exchange (`ssh_exchange_identification`) or `Wait-Bootstrap` times out even though the instance is running. `aws ec2 reboot-instances` appears to succeed but the instance never becomes reachable. SSM `start-session` also times out.
+
+**Cause:** t3 instances earn CPU burst credits at a baseline rate and spend them when CPU demand exceeds the baseline. OpenSearch (1 GB JVM with 1-second Lucene index refresh) and Flowable (Spring Boot JVM) run continuously at low-but-sustained CPU above the t3.xlarge baseline of ~40%. After 4 days of continuous operation this exhausts the credit pool entirely. With zero credits, sshd and the SSM agent are starved of CPU and cannot respond to new connections.
+
+**Fix (live instance):**
+1. Hard-stop the instance (a reboot will not work - the OS is too degraded):
+   ```powershell
+   aws ec2 stop-instances --instance-ids i-<id> --force --region ap-south-1 --profile tazama
+   aws ec2 wait instance-stopped --instance-ids i-<id> --region ap-south-1 --profile tazama
+   aws ec2 start-instances --instance-ids i-<id> --region ap-south-1 --profile tazama
+   ```
+2. While the instance is stopped, switch to unlimited credits (one-time, persistent):
+   ```powershell
+   aws ec2 modify-instance-credit-specification --region ap-south-1 --profile tazama \
+     --instance-credit-specifications '[{"InstanceId":"i-<id>","CpuCredits":"unlimited"}]'
+   ```
+3. After restart, add 4 GB swap manually if the instance was provisioned before the bootstrap hardening was added:
+   ```bash
+   sudo fallocate -l 4G /swapfile && sudo chmod 600 /swapfile && sudo mkswap /swapfile && sudo swapon /swapfile
+   echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+   ```
+
+**Prevention (new instances):** The EC2 module now sets `credit_specification { cpu_credits = "unlimited" }` and the bootstrap script creates the swap file automatically. New instances provisioned via `tofu apply` will not hit this issue.
+
+**OpenSearch root cause:** The default 1-second index refresh interval causes continuous Lucene segment merges. The `extensions/docker-compose.extensions.infrastructure.yaml` now includes an `opensearch-init` one-shot container that applies a 30-second refresh interval, async translog, and 0 replicas on first start - substantially reducing OpenSearch idle CPU.
 
 ---
 

--- a/infra/aws/aws-deployment-instructions.md
+++ b/infra/aws/aws-deployment-instructions.md
@@ -1739,13 +1739,13 @@ Provides the following functions:
 
 Constants defined at script scope (edit here to change region, profile, or branch):
 
-| Constant | Value | Purpose |
-|---|---|---|
-| `$Script:AwsRegion` | `ap-south-1` | AWS region for all CLI calls |
-| `$Script:AwsProfile` | `tazama` | AWS CLI named profile |
-| `$Script:RemoteRepo` | `/home/ec2-user/full-stack-docker-tazama` | Repo path on all three servers |
-| `$Script:RepoBranch` | `dev` | Branch pulled on each server during deploy |
-| `$Script:KeyFile` | `$env:USERPROFILE\.ssh\tazama_ed25519` | EC2 SSH private key (ed25519, in user SSH folder) |
+| Constant | Default value | Override env var | Purpose |
+|---|---|---|---|
+| `$Script:AwsRegion` | `ap-south-1` | `TAZAMA_AWS_REGION` | AWS region for all CLI calls |
+| `$Script:AwsProfile` | `tazama` | `TAZAMA_AWS_PROFILE` | AWS CLI named profile |
+| `$Script:RemoteRepo` | `/home/ec2-user/full-stack-docker-tazama` | - | Repo path on all three servers |
+| `$Script:RepoBranch` | `dev` | - | Branch pulled on each server during deploy |
+| `$Script:KeyFile` | `$env:USERPROFILE\.ssh\id_ed25519` | `TAZAMA_SSH_KEY` | EC2 SSH private key path |
 
 ---
 

--- a/infra/aws/modules/ec2/main.tf
+++ b/infra/aws/modules/ec2/main.tf
@@ -17,6 +17,13 @@ resource "aws_instance" "main" {
     encrypted             = true
   }
 
+  # Keep burst credits unlimited so JVM workloads (OpenSearch, Flowable) never
+  # exhaust the CPU credit pool on t3/t4g instances. Ignored for fixed-
+  # performance families (m5, r5, etc.) that don't have credit specifications.
+  credit_specification {
+    cpu_credits = "unlimited"
+  }
+
   # IMDSv2 required - prevents SSRF-based credential theft via the metadata endpoint.
   metadata_options {
     http_endpoint               = "enabled"

--- a/infra/aws/scripts/helpers.ps1
+++ b/infra/aws/scripts/helpers.ps1
@@ -18,10 +18,13 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 # -- Constants ----------------------------------------------------------------
-# Adjust these if you deploy to a different region or use a different profile.
-$Script:AwsRegion  = 'ap-south-1'
-$Script:AwsProfile = 'tazama'
-$Script:KeyFile    = "$env:USERPROFILE\.ssh\tazama_ed25519"
+# Override any of these via environment variables before dot-sourcing:
+#   $env:TAZAMA_AWS_REGION  - AWS region (default: ap-south-1)
+#   $env:TAZAMA_AWS_PROFILE - AWS CLI profile name (default: tazama)
+#   $env:TAZAMA_SSH_KEY     - Path to your SSH private key (default: ~/.ssh/id_ed25519)
+$Script:AwsRegion  = if ($env:TAZAMA_AWS_REGION)  { $env:TAZAMA_AWS_REGION }  else { 'ap-south-1' }
+$Script:AwsProfile = if ($env:TAZAMA_AWS_PROFILE) { $env:TAZAMA_AWS_PROFILE } else { 'tazama' }
+$Script:KeyFile    = if ($env:TAZAMA_SSH_KEY)      { $env:TAZAMA_SSH_KEY }     else { "$env:USERPROFILE\.ssh\id_ed25519" }
 $Script:RemoteRepo   = '/home/ec2-user/full-stack-docker-tazama'
 $Script:RemoteUser   = 'ec2-user'
 $Script:RepoBranch   = 'dev'

--- a/infra/aws/scripts/helpers.ps1
+++ b/infra/aws/scripts/helpers.ps1
@@ -21,7 +21,7 @@ $ErrorActionPreference = 'Stop'
 # Adjust these if you deploy to a different region or use a different profile.
 $Script:AwsRegion  = 'ap-south-1'
 $Script:AwsProfile = 'tazama'
-$Script:KeyFile    = Join-Path $PSScriptRoot '..\tazama-aws.pem'
+$Script:KeyFile    = "$env:USERPROFILE\.ssh\tazama_ed25519"
 $Script:RemoteRepo   = '/home/ec2-user/full-stack-docker-tazama'
 $Script:RemoteUser   = 'ec2-user'
 $Script:RepoBranch   = 'dev'

--- a/infra/aws/templates/bootstrap.sh.tpl
+++ b/infra/aws/templates/bootstrap.sh.tpl
@@ -19,6 +19,27 @@ EC2_USER="ec2-user"
 
 echo "[bootstrap] Starting - $(date)"
 
+# ── Swap ─────────────────────────────────────────────────────────────────────
+# Provides an OOM safety net for JVM services (OpenSearch, Flowable) on
+# burstable instances. Without swap, the kernel OOM-killer terminates
+# containers rather than spilling to disk when memory spikes briefly.
+echo "[bootstrap] Creating 4 GB swap file..."
+fallocate -l 4G /swapfile
+chmod 600 /swapfile
+mkswap /swapfile
+swapon /swapfile
+echo '/swapfile none swap sw 0 0' >> /etc/fstab
+echo "[bootstrap] Swap enabled: $(swapon --show)"
+
+# ── Docker daemon config ──────────────────────────────────────────────────────
+# Limit container log size so long-running JVM services don't fill the
+# root volume. 50 MB * 3 files = 150 MB max per container.
+mkdir -p /etc/docker
+cat > /etc/docker/daemon.json <<'DOCKEREOF'
+{"log-driver":"json-file","log-opts":{"max-size":"50m","max-file":"3"}}
+DOCKEREOF
+echo "[bootstrap] Docker daemon config written"
+
 # ── Docker CE ────────────────────────────────────────────────────────────────
 echo "[bootstrap] Installing Docker CE..."
 dnf install -y docker git


### PR DESCRIPTION
## Summary

Server B (t3.xlarge) experienced an SSH hang after 4 days of sustained JVM load exhausted its CPU burst credits. This PR fixes the root cause, hardens the infrastructure to prevent recurrence, tunes OpenSearch for its actual workload, and cleans up scripts and docs for community use.

## Changes

### OpenSearch tuning (`extensions/docker-compose.extensions.infrastructure.yaml`)
- Add `restart: always` so OpenSearch recovers automatically on container crash
- Add index buffer and write thread pool tuning env vars (`indices.memory.index_buffer_size=5%`, `thread_pool.write.size=1`, `thread_pool.write.queue_size=500`) - right-sized for low-volume audit logging on a t3.xlarge
- Add `opensearch-init` one-shot service that applies an audit index template on first start (30s refresh interval, async translog, 0 replicas) to reduce write amplification

### Infrastructure hardening (`infra/aws/templates/bootstrap.sh.tpl`, `infra/aws/modules/ec2/main.tf`)
- Bootstrap now creates a 4 GB swap file on every instance before Docker starts - gives the JVM an emergency buffer instead of OOM-killing
- Bootstrap now writes `/etc/docker/daemon.json` with log rotation (`json-file`, 50 MB max, 3 files) before Docker CE installs
- EC2 module sets `cpu_credits = "unlimited"` on all instances so sustained JVM load cannot exhaust burst credits

### Deploy scripts (`infra/aws/scripts/helpers.ps1`)
- Replace hard-coded `ap-south-1`, `tazama` profile, and `tazama_ed25519` key path with env-var overrides (`TAZAMA_AWS_REGION`, `TAZAMA_AWS_PROFILE`, `TAZAMA_SSH_KEY`) - community deployers no longer need to edit source files

### Documentation (`infra/aws/aws-deployment-instructions.md`, `extensions/README.md`)
- Deployment guide: document `credit_specification`, updated bootstrap step order (swap -> daemon.json -> Docker CE), updated helpers catalog table with env var overrides and usage example, new troubleshooting section covering the t3 CPU credit exhaustion root cause and recovery steps
- extensions/README.md: correct OpenSearch description (audit log store, not general search), add `opensearch-init` row to the infrastructure table

## Testing

- OpenSearch tuning and `opensearch-init` will be applied to Server B after this PR is merged by running `restart-extensions-b.ps1`
- Bootstrap and EC2 module changes apply to new instance launches via `tofu apply`
- `TAZAMA_SSH_KEY` override was verified locally - scripts pick up the env var correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added AWS deployment troubleshooting guidance for SSH connectivity and CPU credit issues
  * Updated bootstrap process with new initialization steps

* **New Features**
  * Added OpenSearch initialization service to configure audit log storage
  * Introduced swap file and Docker logging configuration during system bootstrap

* **Configuration**
  * Enabled unlimited CPU credits for t3 EC2 instances
  * Made AWS settings (region, profile, SSH key) environment-variable configurable with sensible defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->