### PR TITLE
fix(extensions): mount auth public key for DEMS and DEAPI on Server A

### DIFF
--- a/extensions/docker-compose.hub.extensions.apis.yaml
+++ b/extensions/docker-compose.hub.extensions.apis.yaml
@@ -12,6 +12,8 @@ services:
     restart: always
     ports:
       - ${DEMS_PORT}:3002
+    volumes:
+      - ./auth/test-public-key.pem:/auth/test-public-key.pem:ro
 
   deapi:
     image: tazamaorg/data-enrichment-service:${TAZAMA_VERSION}
@@ -24,3 +26,5 @@ services:
     restart: always
     ports:
       - ${DEAPI_PORT}:3001
+    volumes:
+      - ./auth/test-public-key.pem:/auth/test-public-key.pem:ro

--- a/infra/aws/scripts/deploy-extensions.ps1
+++ b/infra/aws/scripts/deploy-extensions.ps1
@@ -56,6 +56,17 @@ $overlayFile = Join-Path $PSScriptRoot '..\templates\env-extensions.tpl'
 Set-RemoteEnvOverlay -InstanceId $idA -OverlayFile $overlayFile -RemoteEnvFile "$Script:RemoteRepo/extensions/.env"
 Write-Host '[Server A] .env overlay applied.' -ForegroundColor Green
 
+# -- 1b. Server A: copy auth public key ---------------------------------------
+# DEMS and DEAPI both set AUTH_PUBLIC_KEY_PATH=/auth/test-public-key.pem.
+# The key must exist on Server A before the containers start.
+Write-Host '[Server A] Copying auth public key...'
+$localKey = Join-Path $PSScriptRoot '..\..\..\core\auth\test-public-key.pem'
+Invoke-RemoteCommand -InstanceId $idA -Command "mkdir -p $Script:RemoteRepo/extensions/auth"
+Copy-ToRemote -InstanceId $idA `
+              -LocalPath  $localKey `
+              -RemotePath "$Script:RemoteRepo/extensions/auth/test-public-key.pem"
+Write-Host '[Server A] Auth key copied.' -ForegroundColor Green
+
 # -- 2. Server A: pull latest repo then add DEMS + DEAPI ---------------------
 # DEMS and DEAPI run inside the tazama-core Docker project on Server A.
 # They are not part of the core bat launch chain; they are added here before


### PR DESCRIPTION
## Summary

Fixes #185

DEMS and DEAPI both configure `AUTH_PUBLIC_KEY_PATH=/auth/test-public-key.pem` (and DEMS also `CERT_PATH_PUBLIC=/auth/test-public-key.pem`), but the key was never actually present inside those containers in the AWS deployment. Two gaps:

1. **No volume mount** — `docker-compose.hub.extensions.apis.yaml` had no `volumes:` entry for either service, so the path `/auth/test-public-key.pem` inside the container was always empty.
2. **Key never copied to Server A** — `deploy-extensions.ps1` only copied `test-public-key.pem` to Server B (step 6). DEMS and DEAPI run on Server A inside the `tazama-core` project, so the host path `extensions/auth/test-public-key.pem` never existed there.

## Changes

### `extensions/docker-compose.hub.extensions.apis.yaml`
Add `volumes:` to both `dems` and `deapi` services, mounting the key read-only at the path expected by their env config — matching the pattern already used by `trs-backend` and `cms-backend` in the main extensions compose.

### `infra/aws/scripts/deploy-extensions.ps1`
Add **step 1b** (between the existing env overlay step and the DEMS/DEAPI start step) to copy `core/auth/test-public-key.pem` to `extensions/auth/test-public-key.pem` on Server A, using the same `Copy-ToRemote` pattern as the existing Server B key-copy step.

## Testing

Re-run `deploy-extensions.ps1` to apply. After restart, DEMS and DEAPI should successfully validate JWT tokens and the auth-related failures in TCS, TRS, and CMS should resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration Updates**
  * Updated service and deployment configuration to include automatic authentication credential provisioning. Credentials are now provisioned during startup for API services, ensuring consistent and reliable configuration across all deployment environments without requiring manual setup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->