### PR TITLE
fix: update deapi stream subjects to config.notification

### DIFF
--- a/extensions/env/deapi.env
+++ b/extensions/env/deapi.env
@@ -39,9 +39,9 @@ NATS_PORT=4222
 NATS_HTTP_PORT=8222
 
 STARTUP_TYPE=nats
-PRODUCER_STREAM=enrichment.notification.response
-CONSUMER_STREAM=enrichment.notification
-STREAM_SUBJECT=enrichment.notification
+PRODUCER_STREAM=config.notification.response
+CONSUMER_STREAM=config.notification
+STREAM_SUBJECT=config.notification
 
 ENCRYPTION_KEY=8fj29dkd82hs91kd93kd82hs91kd83ks
 SALT_ROUNDS=10


### PR DESCRIPTION
Updates the DEAPI environment stream subjects from `enrichment.notification` to `config.notification`.\n\n### Changes\n- `PRODUCER_STREAM`: `enrichment.notification.response` → `config.notification.response`\n- `CONSUMER_STREAM`: `enrichment.notification` → `config.notification`\n- `STREAM_SUBJECT`: `enrichment.notification` → `config.notification`