### PR TITLE
fix(auth-service): set CERT_PATH_PUBLIC and mount public key for token verification

### DIFF
--- a/core/docker-compose.base.auth.yaml
+++ b/core/docker-compose.base.auth.yaml
@@ -36,6 +36,7 @@ services:
     restart: always
     volumes:
       - ./auth/test-private-key.pem:/home/app/test-private-key.pem
+      - ./auth/test-public-key.pem:/home/app/test-public-key.pem
     ports:
       - 3020:3020
     depends_on:

--- a/core/env/auth-service.env
+++ b/core/env/auth-service.env
@@ -10,7 +10,7 @@ PORT=3020
 # Auth lib
 AUTH_PROVIDER=@tazama-lf/auth-lib-provider-keycloak
 CERT_PATH_PRIVATE=test-private-key.pem #PKCS8 File
-CERT_PATH_PUBLIC=
+CERT_PATH_PUBLIC=test-public-key.pem
 
 # Provider: @tazama-lf/auth-lib-provider-keycloak 
 AUTH_URL=http://keycloak:8080


### PR DESCRIPTION
## Problem

`FetchGroup()` in the auth-service calls `authenticateRequest()` which calls `verifyToken()` to validate the incoming Bearer token. `verifyToken()` uses `CERT_PATH_PUBLIC` to read the public PEM key via `readFileSync`.

`CERT_PATH_PUBLIC` was blank in `core/env/auth-service.env`, and `test-public-key.pem` was not mounted into the auth container. This caused an `ENOENT: no such file or directory, open ''` crash on every `GET /v1/auth/user/:rolename` request, returning a 500 to callers.

Note: `CERT_PATH_PRIVATE` (the signing key used only during login) was correctly configured. Only the verification key was missing.

## Changes

- `core/env/auth-service.env`: set `CERT_PATH_PUBLIC=test-public-key.pem`
- `core/docker-compose.base.auth.yaml`: mount `./auth/test-public-key.pem` into the auth container alongside the existing private key mount

## Testing

After applying this fix and recreating the auth container, the `ENOENT` error is gone and `FetchGroup()` progresses past token verification to the Keycloak Admin API call.