### PR TITLE
fix: remove UTF-8 BOM from core docker-compose files

### DIFF
--- a/core/docker-compose.base.auth.yaml
+++ b/core/docker-compose.base.auth.yaml
@@ -1,4 +1,4 @@
-﻿# For local testing
+# For local testing
 
 services:
   # AUTH PROVIDER

--- a/core/docker-compose.full.cfg.yaml
+++ b/core/docker-compose.full.cfg.yaml
@@ -1,4 +1,4 @@
-﻿services:
+services:
   postgres:
     command: postgres -N 1000 -c shared_buffers=512MB -c effective_cache_size=2GB
     volumes:

--- a/core/docker-compose.full.rules.yaml
+++ b/core/docker-compose.full.rules.yaml
@@ -1,4 +1,4 @@
-﻿# For local testing
+# For local testing
 services:
   # RULE 001
   rule-001:

--- a/core/docker-compose.hub.rules.yaml
+++ b/core/docker-compose.hub.rules.yaml
@@ -1,4 +1,4 @@
-﻿# For local testing
+# For local testing
 services:
   rule-901:
     image: tazamaorg/rule-901:${TAZAMA_VERSION}

--- a/core/docker-compose.hub.ui.yaml
+++ b/core/docker-compose.hub.ui.yaml
@@ -1,4 +1,4 @@
-﻿services:
+services:
   ui:
     image: tazamaorg/demo-ui:v2.2.0
     restart: always

--- a/core/docker-compose.multitenant.cfg.yaml
+++ b/core/docker-compose.multitenant.cfg.yaml
@@ -1,4 +1,4 @@
-﻿services:
+services:
   postgres:
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust

--- a/core/docker-compose.utils.hasura.yaml
+++ b/core/docker-compose.utils.hasura.yaml
@@ -1,4 +1,4 @@
-﻿services:
+services:
   postgres:
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust

--- a/core/docker-compose.utils.pgadmin.yaml
+++ b/core/docker-compose.utils.pgadmin.yaml
@@ -1,4 +1,4 @@
-﻿services:
+services:
   pgadmin:
     image: dpage/pgadmin4:9
     env_file:


### PR DESCRIPTION
Strips the UTF-8 BOM (EF BB BF) from 9 docker-compose YAML files in \core/\ that were created with BOM encoding. These files would fail the \ncoding-check\ Action if they appeared in a future PR diff.