### PR TITLE
fix: update warehouse host path to /opt/Warehouse

### DIFF
--- a/biar/README.md
+++ b/biar/README.md
@@ -202,7 +202,7 @@ Tazama BIAR application services. The `hub` variant pulls pre-built images from 
 | JupyterHub | `biar-jupyterhub` | 8000 | Multi-user analytics environment. Each user gets an isolated JupyterLab session with pre-loaded PySpark notebooks. Uses `NativeAuthenticator` (sign-up on first visit). |
 
 > [!NOTE]
-> `TAZAMA_WAREHOUSE_HOST_PATH` in `biar/.env` controls where the Hudi warehouse is stored on the host. In the AWS deployment this is `/opt/Tazama_Warehouse` (created by `deploy-biar.ps1`). In a local deployment, set this to any directory you have write access to.
+> `TAZAMA_WAREHOUSE_HOST_PATH` in `biar/.env` controls where the Hudi warehouse is stored on the host. In the AWS deployment this is `/opt/Warehouse` (created by `deploy-biar.ps1`). In a local deployment, set this to any directory you have write access to.
 
 ## 5.3. Init containers (docker-compose.utils.init.yaml)
 

--- a/infra/aws/main.tf
+++ b/infra/aws/main.tf
@@ -175,7 +175,7 @@ module "server_c" {
   security_group_ids   = [module.security_groups.server_c_sg_id]
   key_name             = var.key_name
   ami_id               = data.aws_ami.al2023.id
-  root_volume_size     = 100
+  root_volume_size     = 150
   iam_instance_profile = aws_iam_instance_profile.ec2_ssm.name
   user_data            = local.bootstrap
 }

--- a/infra/aws/scripts/deploy-biar.ps1
+++ b/infra/aws/scripts/deploy-biar.ps1
@@ -74,7 +74,7 @@ Write-Host '[Server C] .env overlay applied.' -ForegroundColor Green
 # automation-orchestrator and datalakehouse-api bind-mount this path.
 # Docker will fail to start the containers if the directory does not exist.
 Write-Host '[Server C] Creating Tazama warehouse directory...'
-Invoke-RemoteCommand -InstanceId $idC -Command 'sudo mkdir -p /opt/Tazama_Warehouse && sudo chown ec2-user:ec2-user /opt/Tazama_Warehouse'
+Invoke-RemoteCommand -InstanceId $idC -Command 'sudo mkdir -p /opt/Warehouse && sudo chown ec2-user:ec2-user /opt/Warehouse'
 Write-Host '[Server C] Warehouse directory ready.' -ForegroundColor Green
 
 # -- 5. Start biar stack (staged Ozone startup) --------------------------------
@@ -100,6 +100,16 @@ Invoke-RemoteCommand -InstanceId $idC -Command "cd $Script:RemoteRepo/biar && do
 # Step 5c: Wait for OM, then bring up the full stack
 Write-Host '[Server C] Waiting 15s for OM to initialise...'
 Start-Sleep -Seconds 15
+
+# Prune unused images before pulling to ensure there is enough disk headroom.
+# --pull always downloads the new image before removing the old one, so without
+# this step a full disk will abort the pull mid-stream.
+if (-not $NoPull) {
+    Write-Host '[Server C] Pruning unused Docker images to free disk space...'
+    Invoke-RemoteCommand -InstanceId $idC -Command 'docker image prune -af'
+    Write-Host '[Server C] Image prune complete.' -ForegroundColor Green
+}
+
 Write-Host '[Server C] Starting full biar stack...'
 Invoke-RemoteCommand -InstanceId $idC -Command "cd $Script:RemoteRepo/biar && docker compose -p tazama-biar -f $infraFile -f $hubFile -f $utilsFile up -d $pullFlag".Trim()
 

--- a/infra/aws/scripts/deploy-lakehouse.ps1
+++ b/infra/aws/scripts/deploy-lakehouse.ps1
@@ -2,7 +2,7 @@
 #
 # deploy-lakehouse.ps1
 # Stages a large Lakehouse zip archive through S3 and unpacks it on Server C
-# into /opt/Tazama_Warehouse.
+# into /opt/Warehouse.
 #
 # Why S3 and not SCP?  The file is typically 3-4 GB.  EICE tunnels are
 # stdio-based and throttled — SCP over EICE for that size would take hours
@@ -53,7 +53,7 @@ Write-Host "Staging bucket: $stateBucket"
 
 $s3Key     = "lakehouse-staging/Tazama_Lakehouse.zip"
 $s3Uri     = "s3://$stateBucket/$s3Key"
-$warehouseDir = "/opt/Tazama_Warehouse"
+$warehouseDir = "/opt/Warehouse"
 $region    = "ap-south-1"
 $profile   = "tazama"
 
@@ -85,8 +85,8 @@ sudo mkdir -p $warehouseDir
 # Download from S3 — uses the instance IAM role, no credentials needed
 echo "Downloading from S3..."
 aws s3 cp $s3Uri /home/ec2-user/Tazama_Lakehouse.zip --region $region
-# Unpack to / — the zip already contains the full path (opt/Tazama_Warehouse/...)
-# so extracting to -d / lands files at /opt/Tazama_Warehouse/ directly.
+# Unpack to / — the zip already contains the full path (opt/Warehouse/...)
+# so extracting to -d / lands files at /opt/Warehouse/ directly.
 # Using -d $warehouseDir would double-nest the path.
 echo "Unpacking..."
 sudo unzip -o /home/ec2-user/Tazama_Lakehouse.zip -d /


### PR DESCRIPTION
Updates `TAZAMA_WAREHOUSE_HOST_PATH` from `/opt/Tazama_Warehouse` to `/opt/Warehouse` to align with the new Data Lakehouse directory structure.

## Changes

- `infra/aws/scripts/deploy-biar.ps1`: creates `/opt/Warehouse` on Server C; adds Docker image prune step before stack startup to free disk headroom
- `infra/aws/scripts/deploy-lakehouse.ps1`: unpacks lakehouse archive to `/opt/Warehouse`
- `infra/aws/main.tf`: increases Server C root volume from 100 GB to 150 GB
- `biar/README.md`: docs updated to reference new path
