### PR TITLE
fix: restore -RepoPull branch parameter in restart-service.ps1

### DIFF
--- a/extensions/env/deapi.env
+++ b/extensions/env/deapi.env
@@ -56,6 +56,7 @@ APM_SERVICE_NAME=data-enrichment-service
 TAZAMA_AUTH_URL=http://auth:3020/v1/auth
 
 AUTH_PUBLIC_KEY_PATH=/auth/test-public-key.pem
+CERT_PATH_PUBLIC=/auth/test-public-key.pem
 
 # SIDECAR
 SIDECAR_HOST=event-sidecar:${EVENT_SIDECAR_PORT}

--- a/infra/aws/aws-deployment-instructions.md
+++ b/infra/aws/aws-deployment-instructions.md
@@ -1894,39 +1894,41 @@ on the state bucket; the EC2 instance role must have `s3:GetObject` on the
 
 [infra/aws/scripts/restart-service.ps1](full-stack-docker-tazama/infra/aws/scripts/restart-service.ps1)
 
-Pulls the latest repo changes and image for a single Docker Compose service
-and recreates its container without touching any other running containers.
+Pulls the latest image for a single Docker Compose service and recreates its
+container without touching any other running containers.  Optionally fetches
+a specific branch of the repo on the target server before recreating, which
+is the recommended way to roll out a committed fix without a full redeploy.
 
 The script reads the running container's `com.docker.compose` labels to
 discover the exact working directory and compose file chain used to start it,
-then runs `git pull` in that directory followed by a targeted
-`docker compose up --no-deps --force-recreate`.  This means the command is
-always reconstructed from live state - no hardcoded file chains that can go stale.
+then issues a targeted `docker compose up --no-deps --force-recreate`.  This
+means the command is always reconstructed from live state — no hardcoded file
+chains that can go stale.
 
 Server A's two sub-chains (`tazama-core` main stack and extensions APIs) are
 handled transparently by this label-based approach.
 
 ```powershell
-# Update admin-service on Server A (pulls repo + image)
+# Update admin-service on Server A (pulls image, no repo pull)
 .\restart-service.ps1 -Server A -Service admin-service
 
-# Update deapi (extensions API running on Server A)
-.\restart-service.ps1 -Server A -Service deapi
+# Roll out a committed fix from a branch, then recreate the container
+.\restart-service.ps1 -Server A -Service deapi -RepoPull fix-biar-data-pipeline
 
-# Update tcs-api on Server B
+# Roll out latest dev branch changes and recreate
+.\restart-service.ps1 -Server A -Service deapi -RepoPull dev
+
+# Update tcs-api on Server B (image pull only, no repo pull)
 .\restart-service.ps1 -Server B -Service tcs-api
 
 # Update NiFi on Server C
 .\restart-service.ps1 -Server C -Service nifi
 
 # Apply a repo change (e.g. updated env file) without pulling a new image
-.\restart-service.ps1 -Server C -Service automation-orchestrator -NoPull
-
-# Pull a new image without applying pending repo changes
-.\restart-service.ps1 -Server B -Service cms-frontend -NoRepoPull
+.\restart-service.ps1 -Server C -Service automation-orchestrator -NoPull -RepoPull dev
 
 # Force recreate only - skip both pulls (e.g. restart a crashed container)
-.\restart-service.ps1 -Server B -Service cms-frontend -NoPull -NoRepoPull
+.\restart-service.ps1 -Server B -Service cms-frontend -NoPull
 ```
 
 | Parameter | Description |
@@ -1934,7 +1936,7 @@ handled transparently by this label-based approach.
 | `-Server` | **Required.** `A`, `B`, or `C`. |
 | `-Service` | **Required.** Docker Compose service name (e.g. `rule-001`, `tcs-api`, `nifi`). |
 | `-NoPull` | Skip the DockerHub image pull (`--pull always`). Use when the image is already current. |
-| `-NoRepoPull` | Skip the `git pull` of the full-stack-docker-tazama repo on the target server. Use when you want to apply an image update without pulling pending repo changes. |
+| `-RepoPull` | Controls the repo update on the target server before recreating the container. Omitted or `none` — skip entirely (default); `''` or `dev` — fetch and reset to `origin/dev`; `<branch>` — fetch and reset to that branch. |
 
 After recreating, the script prints a `docker ps` table confirming the
 container name, status, and image digest.

--- a/infra/aws/scripts/restart-service.ps1
+++ b/infra/aws/scripts/restart-service.ps1
@@ -34,11 +34,18 @@
     Skip the DockerHub image pull step.  Useful when the latest image is already
     present on the host and you only want to force a config/env recreate.
 
-.PARAMETER NoRepoPull
-    Skip the 'git pull' of the full-stack-docker-tazama repo on the target
-    server before recreating the container.  Useful when you want to pull a
-    fresh image without applying any pending repo changes, or when the working
-    directory is not a git repo.
+.PARAMETER RepoPull
+    Controls whether the full-stack-docker-tazama repo is updated on the target
+    server before recreating the container.
+
+      Omitted / 'none'        - skip the repo pull entirely (fastest; use the
+                                code already on the server)
+      '' (empty) or 'dev'     - fetch and reset to origin/dev
+      '<branch>'              - fetch and reset to origin/<branch>
+
+    Using a branch name switches the server to that branch before recreating,
+    which is the recommended way to roll out a committed fix without a full
+    redeploy.
 
 .EXAMPLE
     .\restart-service.ps1 -Server A -Service rule-001
@@ -46,8 +53,10 @@
     .\restart-service.ps1 -Server B -Service tcs-api
     .\restart-service.ps1 -Server C -Service nifi
     .\restart-service.ps1 -Server C -Service automation-orchestrator -NoPull
-    .\restart-service.ps1 -Server B -Service cms-frontend -NoRepoPull
-    .\restart-service.ps1 -Server B -Service cms-frontend -NoPull -NoRepoPull
+    .\restart-service.ps1 -Server B -Service cms-frontend
+    .\restart-service.ps1 -Server B -Service cms-frontend -NoPull
+    .\restart-service.ps1 -Server A -Service deapi -RepoPull fix-biar-data-pipeline
+    .\restart-service.ps1 -Server A -Service deapi -RepoPull dev
 #>
 
 [CmdletBinding()]
@@ -61,7 +70,8 @@ param(
 
     [switch]$NoPull,
 
-    [switch]$NoRepoPull
+    # 'none' (or omitted) = skip pull; '' or 'dev' = pull dev; '<branch>' = pull that branch.
+    [string]$RepoPull = 'none'
 )
 
 . "$PSScriptRoot\helpers.ps1"
@@ -77,12 +87,15 @@ switch ($Server) {
 
 $pullFlag = if ($NoPull) { '' } else { '--pull always' }
 
+# Resolve the effective branch: omitted or 'none' → skip; '' → 'dev'; else use as-is.
+$effectiveBranch = if ($RepoPull -eq 'none') { '' } elseif ($RepoPull -eq '') { 'dev' } else { $RepoPull }
+
 Write-Host ''
 Write-Host "=== Restart service: $Service on $label ===" -ForegroundColor Cyan
-Write-Host "[$label] Project : $project"
-Write-Host "[$label] Service : $Service"
-Write-Host "[$label] Pull    : $(-not $NoPull) (DockerHub image)"
-Write-Host "[$label] RepoPull: $(-not $NoRepoPull) (full-stack git pull)"
+Write-Host "[$label] Project   : $project"
+Write-Host "[$label] Service   : $Service"
+Write-Host "[$label] Pull      : $(-not $NoPull) (DockerHub image)"
+Write-Host "[$label] RepoPull  : $(if ($effectiveBranch) { $effectiveBranch } else { 'none' })"
 Write-Host ''
 
 # -- Discover compose context from the running container's labels ----------------------------
@@ -140,9 +153,10 @@ Write-Host "[$label] Working dir: $workingDir"
 $fFlags = ($configFiles -split ',' | ForEach-Object { "-f $_" }) -join ' '
 
 # -- Repo pull ------------------------------------------------------------------------------
-if (-not $NoRepoPull) {
-    Write-Host "[$label] Pulling latest full-stack repo in $workingDir..."
-    Invoke-RemoteCommand -InstanceId $instanceId -Command "cd $workingDir && git pull"
+if ($effectiveBranch) {
+    Write-Host "[$label] Pulling branch '$effectiveBranch' in $workingDir..."
+    Invoke-RemoteCommand -InstanceId $instanceId -Command `
+        "cd $workingDir && git fetch origin $effectiveBranch && git checkout $effectiveBranch && git reset --hard origin/$effectiveBranch"
 }
 
 # -- Recreate -------------------------------------------------------------------------------


### PR DESCRIPTION
Restores the `-RepoPull` string parameter in `restart-service.ps1` that was silently dropped during the merge conflict resolution when `deapi-env-update` (PR #187) was merged into `dev`. The changes were originally committed in `a27ff61` on `fix-biar-data-pipeline`.

## Changes

- `infra/aws/scripts/restart-service.ps1`: replaces `[switch]$NoRepoPull` with `[string]$RepoPull = 'none'`, supporting three modes:
  - Omitted / `none` — skip repo pull entirely (new default)
  - `''` or `dev` — fetch and reset to `origin/dev`
  - `<branch>` — fetch and reset to `origin/<branch>`
- `infra/aws/aws-deployment-instructions.md`: updates docs and examples to reflect the new parameter
