### PR TITLE
fix: correct DEAPI/DEMS server placement in restart-service docs

### DIFF
--- a/infra/aws/aws-deployment-instructions.md
+++ b/infra/aws/aws-deployment-instructions.md
@@ -1905,17 +1905,19 @@ then issues a targeted `docker compose up --no-deps --force-recreate`.  This
 means the command is always reconstructed from live state — no hardcoded file
 chains that can go stale.
 
-Server A's two sub-chains (`tazama-core` main stack and extensions APIs) are
-handled transparently by this label-based approach.
+Server A hosts two compose sub-chains under `tazama-core`: the main core
+services and the extensions APIs (DEMS + DEAPI — these run on Server A from
+the `extensions/` compose files, not on Server B). Server B and C stacks are
+handled the same way via their own project labels.
 
 ```powershell
 # Update admin-service on Server A (pulls image, no repo pull)
 .\restart-service.ps1 -Server A -Service admin-service
 
-# Roll out a committed fix from a branch, then recreate the container
+# Roll out a committed fix from a branch, then recreate DEAPI (Server A - extensions)
 .\restart-service.ps1 -Server A -Service deapi -RepoPull fix-biar-data-pipeline
 
-# Roll out latest dev branch changes and recreate
+# Roll out latest dev branch changes and recreate DEAPI (Server A - extensions)
 .\restart-service.ps1 -Server A -Service deapi -RepoPull dev
 
 # Update tcs-api on Server B (image pull only, no repo pull)

--- a/infra/aws/scripts/restart-service.ps1
+++ b/infra/aws/scripts/restart-service.ps1
@@ -16,7 +16,7 @@
 
     Server A runs two compose sub-chains under the same tazama-core project:
       - the main core stack (rules, TP, TMS, auth, relay, logs, pgAdmin, Hasura)
-      - the extensions APIs (deapi, dems)
+      - the extensions APIs (deapi, dems) — deployed from extensions/ compose files
     Because the working directory and config-file list are read from the live
     container, both sub-chains are handled transparently by the same script.
 


### PR DESCRIPTION
## Summary

Corrects documentation that implied DEAPI and DEMS run on Server B. They run on Server A, launched from the `extensions/` compose files.

## Changes

- `infra/aws/aws-deployment-instructions.md` - Clarifies that DEAPI/DEMS are deployed from `extensions/` compose files on Server A, not Server B; updates example command comments accordingly.
- `infra/aws/scripts/restart-service.ps1` - Adds a note in the script header that the extensions APIs are deployed from `extensions/` compose files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Clarified AWS deployment instructions for Server A, detailing how the core services and extensions APIs are deployed separately using different compose configurations.
* Updated deployment script documentation to specify the proper deployment source for extensions APIs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tazama-lf/Full-Stack-Docker-Tazama/pull/215)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->