### PR TITLE
feat: add batch-ppa to AWS full-stack deployment

### DIFF
--- a/core/docker-compose.utils.batch-ppa.yaml
+++ b/core/docker-compose.utils.batch-ppa.yaml
@@ -1,9 +1,6 @@
 ﻿services:
-  nats-utilities:
-    build:
-      context: https://github.com/tazama-lf/batch-ppa.git#${BATCH_PPA_BRANCH}
-      args:
-        - GH_TOKEN
+  batch-ppa:
+    image: tazamaorg/batch-ppa:${TAZAMA_VERSION}
     env_file:
       - env/batch-ppa.env
       - .env

--- a/core/env/batch-ppa.env
+++ b/core/env/batch-ppa.env
@@ -1,15 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # APP
-FUNCTION_NAME=transaction-monitoring-service
+FUNCTION_NAME=batch-ppa
 MAX_CPU=1
-PORT=3000
-QUOTING=false
+AUTHENTICATED=true
+PORT=4000
 NODE_ENV=dev
 SIDECAR_HOST=event-sidecar:${EVENT_SIDECAR_PORT}
 
 # APM
-APM_SERVICE_NAME=tms-service
+APM_SERVICE_NAME=batch-ppa
 APM_URL=http://apm:8200
 APM_SECRET_TOKEN=
 APM_ACTIVE=false

--- a/infra/aws/aws-deployment-instructions.md
+++ b/infra/aws/aws-deployment-instructions.md
@@ -1125,6 +1125,7 @@ Four security groups. EC2 instances have **no internet-facing inbound rules** - 
 | Inbound | 3020 | TCP | `0.0.0.0/0` | Auth Service |
 | Inbound | 8080 | TCP | `0.0.0.0/0` | Keycloak |
 | Inbound | 6100 | TCP | `0.0.0.0/0` | Hasura |
+| Inbound | 4000 | TCP | `0.0.0.0/0` | batch-ppa |
 | Inbound | 3005–3090 | TCP | `0.0.0.0/0` | TRS / TCS / CMS backends |
 | Inbound | 5173–5175 | TCP | `0.0.0.0/0` | TCS / TRS / CMS frontends |
 | Inbound | 18866 | TCP | `0.0.0.0/0` | Voila (CMS notebook server) |
@@ -1143,6 +1144,7 @@ Four security groups. EC2 instances have **no internet-facing inbound rules** - 
 | Inbound | 8080 | TCP | sg-tazama-alb | Keycloak |
 | Inbound | 5050–5051 | TCP | sg-tazama-alb | pgAdmin |
 | Inbound | 6100 | TCP | sg-tazama-alb | Hasura |
+| Inbound | 4000 | TCP | sg-tazama-alb | batch-ppa |
 | Inbound | 0–65535 | TCP | `10.0.1.0/24` | Cross-server (NATS :14222, PostgreSQL :15432, Valkey :16379, etc.) |
 | Inbound | 22 | TCP | sg-tazama-eice | SSH via EICE endpoint only |
 | Outbound | All | All | `0.0.0.0/0` | Image pulls, GitHub builds |
@@ -1519,6 +1521,7 @@ docker compose -p tazama-core \
   -f ./docker-compose.hub.logs.base.yaml \
   -f ./docker-compose.utils.pgadmin.yaml \
   -f ./docker-compose.utils.hasura.yaml \
+  -f ./docker-compose.utils.batch-ppa.yaml \
   up -d [--pull always]
 ```
 
@@ -2035,6 +2038,7 @@ Forwards Server A service ports to `localhost`. Press **Ctrl+C** to close.
 | `3020` | Auth Service |
 | `8080` | Keycloak |
 | `6100` | Hasura GraphQL |
+| `4000` | batch-ppa |
 | `5050` | pgAdmin |
 | `14222` | NATS (exterior) |
 | `15432` | PostgreSQL (exterior) |

--- a/infra/aws/modules/alb/main.tf
+++ b/infra/aws/modules/alb/main.tf
@@ -29,6 +29,7 @@ locals {
     keycloak     = { port = 8080, server = "a" }
     pgadmin      = { port = 5050, server = "a" }
     hasura       = { port = 6100, server = "a" }
+    batch-ppa    = { port = 4000, server = "a" }
     tcs-frontend = { port = 5173, server = "b" }
     tcs-api      = { port = 3010, server = "b" }
     trs-frontend = { port = 5174, server = "b" }

--- a/infra/aws/modules/security-groups/main.tf
+++ b/infra/aws/modules/security-groups/main.tf
@@ -71,6 +71,14 @@ resource "aws_security_group" "alb" {
   }
 
   ingress {
+    description = "batch-ppa"
+    from_port   = 4000
+    to_port     = 4000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
     description = "DEAPI / DEMS (Server A)"
     from_port   = 3001
     to_port     = 3002
@@ -175,6 +183,14 @@ resource "aws_security_group" "server_a" {
     description     = "Hasura"
     from_port       = 6100
     to_port         = 6100
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  ingress {
+    description     = "batch-ppa"
+    from_port       = 4000
+    to_port         = 4000
     protocol        = "tcp"
     security_groups = [aws_security_group.alb.id]
   }

--- a/infra/aws/scripts/deploy-core.ps1
+++ b/infra/aws/scripts/deploy-core.ps1
@@ -147,6 +147,7 @@ $composeArgs = @(
     '-f ./docker-compose.hub.logs.base.yaml'
     '-f ./docker-compose.utils.pgadmin.yaml'
     '-f ./docker-compose.utils.hasura.yaml'
+    '-f ./docker-compose.utils.batch-ppa.yaml'
 ) -join ' '
 
 $maxAttempts = 3


### PR DESCRIPTION
## Summary

Adds `batch-ppa` to the AWS three-server full-stack deployment.

## Changes

### `core/env/batch-ppa.env`
Rewritten with correct batch-ppa configuration:
- `FUNCTION_NAME=batch-ppa`
- `PORT=4000`
- `AUTHENTICATED=true`
- `TMS_ENDPOINT=http://tms:5000`
- `DELIMITER=|`

Previously contained a copy of the TMS service config.

### `core/docker-compose.utils.batch-ppa.yaml`
- Changed from a GitHub source build to the published DockerHub image (`tazamaorg/batch-ppa:${TAZAMA_VERSION}`)
- Renamed service from `nats-utilities` to `batch-ppa`

### `infra/aws/scripts/deploy-core.ps1`
- Added `-f ./docker-compose.utils.batch-ppa.yaml` to the compose chain

### `infra/aws/modules/alb/main.tf`
- Added `batch-ppa = { port = 4000, server = "a" }` to the ALB services map - creates a target group and HTTP listener on port 4000

### `infra/aws/modules/security-groups/main.tf`
- Added port 4000 ingress rule to the ALB security group
- Added port 4000 ingress rule to the Server A security group (sourced from ALB SG)

### `infra/aws/aws-deployment-instructions.md`
- Updated compose chain table
- Added port 4000 rows to ALB SG and Server A SG reference tables
- Added batch-ppa to the Server A port reference table

## Related

- `tazama-lf/batch-ppa` - auth and tenant propagation changes merged in #227
