### PR TITLE
feat(infra/aws): expose CouchDB console via ALB at couchdb.beta.tazama.org

### DIFF
--- a/infra/aws/aws-deployment-instructions.md
+++ b/infra/aws/aws-deployment-instructions.md
@@ -1131,7 +1131,7 @@ Four security groups. EC2 instances have **no internet-facing inbound rules** - 
 | Inbound | 8088 | TCP | `0.0.0.0/0` | NiFi UI |
 | Outbound | All | All | `0.0.0.0/0` | Routing to EC2 target groups |
 
-> JupyterHub (:8000), Automation Orchestrator (:7619), and Datalakehouse API (:8282) have ALB target groups and listeners, but their ports are **not** open in the ALB SG - they are accessed via SSH tunnel (Phase E.1). Add them to the ALB SG when exposing them publicly.
+> JupyterHub (:8000), Automation Orchestrator (:7619), Datalakehouse API (:8282), and CouchDB (:5984) have ALB target groups and listeners, but their ports are **not** open in the ALB SG - they are accessed via the HTTPS subdomain (port 443) or SSH tunnel (Phase E.1). Add the plain HTTP port to the ALB SG only if port-based HTTP access is needed.
 
 #### sg-tazama-server-a (Server A - tazama-core)
 
@@ -1156,6 +1156,7 @@ Four security groups. EC2 instances have **no internet-facing inbound rules** - 
 | Inbound | 5173–5175 | TCP | sg-tazama-alb | TCS / TRS / CMS frontends |
 | Inbound | 18866 | TCP | sg-tazama-alb | Voila (CMS notebook server) |
 | Inbound | 5051 | TCP | sg-tazama-alb | pgAdmin (extensions) |
+| Inbound | 5984 | TCP | sg-tazama-alb | CouchDB (health check only - port not in ALB SG) |
 | Inbound | 0–65535 | TCP | `10.0.1.0/24` | Cross-server (OpenSearch :9200, PostgreSQL :15433, etc.) |
 | Inbound | 22 | TCP | sg-tazama-eice | SSH via EICE endpoint only |
 | Outbound | All | All | `0.0.0.0/0` | Image pulls, GitHub builds, Server A calls |
@@ -3319,6 +3320,7 @@ docker compose -p tazama-core \
 | 5174 | TRS Frontend | ALB | `trs` |
 | 5175 | CMS Frontend | ALB | `cms` |
 | 18866 | Voila notebook server | ALB | `voila` |
+| 5984 | CouchDB | ALB | `couchdb` |
 | 9200 | OpenSearch | (NiFi ETL - pending confirmation) | - |
 | 12222 | SFTP | File ingest | - |
 | 15433 | PostgreSQL (CMS) | Server C NiFi ETL | - |

--- a/infra/aws/modules/alb/main.tf
+++ b/infra/aws/modules/alb/main.tf
@@ -37,7 +37,8 @@ locals {
     cms-frontend = { port = 5175, server = "b" }
     cms-api      = { port = 3090, server = "b" }
     voila        = { port = 18866, server = "b" }
-    pgadmin-ext           = { port = 5051, server = "b" }
+    pgadmin-ext  = { port = 5051,  server = "b" }
+    couchdb      = { port = 5984,  server = "b" }
     nifi                    = { port = 8088, server = "c" }
     jupyterhub              = { port = 8000, server = "c" }
     auto-orchestrator       = { port = 7619, server = "c" }
@@ -63,6 +64,7 @@ locals {
     trs-api     = "/api/docs"
     tcs-api     = "/api/docs"
     voila       = "/voila/"
+    couchdb     = "/"
   }
 }
 

--- a/infra/aws/modules/dns-public/main.tf
+++ b/infra/aws/modules/dns-public/main.tf
@@ -93,6 +93,7 @@ locals {
     automation-orchestrator = var.target_group_arns["auto-orchestrator"]
     datalakehouse-api       = var.target_group_arns["datalakehouse-api"]
     batch-ppa               = var.target_group_arns["batch-ppa"]
+    couchdb                 = var.target_group_arns["couchdb"]
   }
 
   # Explicit priorities — must match the actual AWS state exactly.
@@ -120,6 +121,7 @@ locals {
     dems                    = 21
     voila                   = 22
     batch-ppa               = 23
+    couchdb                 = 24
   }
 }
 

--- a/infra/aws/modules/security-groups/main.tf
+++ b/infra/aws/modules/security-groups/main.tf
@@ -262,6 +262,14 @@ resource "aws_security_group" "server_b" {
     security_groups = [aws_security_group.alb.id]
   }
 
+  ingress {
+    description     = "CouchDB (ALB health check - port not exposed in ALB SG)"
+    from_port       = 5984
+    to_port         = 5984
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
   # Allows Server C to reach OpenSearch (9200) and PostgreSQL (15433) on Server B.
   ingress {
     description = "Cross-server traffic from private subnet"


### PR DESCRIPTION
## Summary

Exposes the CouchDB Fauxton console via the ALB at `https://couchdb.beta.tazama.org`.

## Changes

- **`infra/aws/modules/alb/main.tf`** - Add `couchdb` to the ALB services map (port 5984, Server B) with health check path `/`
- **`infra/aws/modules/security-groups/main.tf`** - Add port 5984 ingress on the Server B SG from the ALB SG, allowing ALB health checks to reach CouchDB (the port remains absent from the ALB SG inbound rules so direct HTTP access is not possible)
- **`infra/aws/modules/dns-public/main.tf`** - Add `couchdb` to the subdomain map and priority map (priority 24), creating a Route 53 A record and HTTPS listener rule for `couchdb.beta.tazama.org`
- **`infra/aws/aws-deployment-instructions.md`** - Update ALB SG footnote, Server B SG table, and Server B port map to reflect CouchDB as ALB-exposed

## Access

`https://couchdb.beta.tazama.org` routes via the HTTPS wildcard cert to the CouchDB Fauxton UI on Server B. Port 5984 is not open on the ALB SG - all access is through the HTTPS listener (port 443) via host-based routing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AWS deployment instructions to clarify CouchDB accessibility, including HTTPS subdomain routing and SSH tunneling options.

* **Chores**
  * Integrated CouchDB service into AWS infrastructure with health checks, DNS routing, and network security configuration for secure backend connectivity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tazama-lf/Full-Stack-Docker-Tazama/pull/227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->