### PR TITLE
fix: cap Flowable heap + fix Voila health check (no curl in image)

### DIFF
--- a/extensions/docker-compose.extensions.infrastructure.yaml
+++ b/extensions/docker-compose.extensions.infrastructure.yaml
@@ -62,6 +62,9 @@ services:
       - migrate
     env_file:
       - ./env/cms.env
+    environment:
+      - JAVA_TOOL_OPTIONS=-Xms256m -Xmx1536m
+    mem_limit: 2g
     ports:
       - "${FLOWABLE_PORT}:8080"
 

--- a/extensions/docker-compose.hub.extensions.yaml
+++ b/extensions/docker-compose.hub.extensions.yaml
@@ -112,7 +112,7 @@ services:
     ports:
       - "${VOILA_PORT}:8866"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8866/"]
+      test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:8866/')\""]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary

Two compose fixes addressing root causes of the Server B recurring crash (Docker daemon deadlock caused by ECS agent crash-loop, compounded by excessive Docker API churn from a broken health check).

## Changes

### Flowable JVM cap (`docker-compose.extensions.infrastructure.yaml`)
- Added `JAVA_TOOL_OPTIONS=-Xms256m -Xmx1536m` - bounds the Spring Boot / Flowable BPMN JVM heap. Without this, Flowable has no upper limit and expands freely under workflow load, competing directly with OpenSearch and other services for the 16 GB available on Server B.
- Added `mem_limit: 2g` - hard container cap so the kernel OOM killer has a predictable target if the JVM somehow exceeds its heap limit, rather than killing unrelated containers.

### Voila health check fix (`docker-compose.hub.extensions.yaml`)
- Replaced `["CMD", "curl", "-f", "http://localhost:8866/"]` with `["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:8866/')\""]`
- `curl` is not present in the `tazama-cms-voila` image. The broken check caused Docker daemon to emit `OCI runtime exec failed` errors every 30 seconds, contributing to the background API churn that eventually deadlocked dockerd after 12 days of uptime. Python is guaranteed available in any voila container.

## Root cause context

Server B crashed after 12 days because `ecs.service` (AWS ECS container agent) is enabled on the instance despite it not being an ECS cluster node. It crash-loops at ~3-4 cycles/minute (~64,000 container lifecycle events over 12 days), and the broken Voila health check added ~2 Docker exec API calls/minute on top. This sustained churn eventually caused a Docker daemon goroutine deadlock. These compose changes reduce the churn and cap Flowable memory. The ECS service itself must be disabled directly on the instance (`sudo systemctl disable --now ecs amazon-ecs-volume-plugin`) - that is not a repo change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container reliability for the notebook service by updating its health check to use a more robust connectivity test.
* **Chores**
  * Adjusted resource settings for one backend service to use a defined memory limit and startup memory options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->