### PR TITLE
fix: add VOILA_BASE_URL to cms.env (cms-backend crashloop)

### DIFF
--- a/extensions/env/cms.env
+++ b/extensions/env/cms.env
@@ -78,6 +78,7 @@ COUCHDB_PASSWORD=1234
 
 # Visualization and Lakehouse
 VOILA_URL=http://tazama-cms-voila:8866
+VOILA_BASE_URL=http://tazama-cms-voila:8866
 CMS_FRONTEND_ORIGIN=http://localhost:5175
 GOLD_LAKEHOUSE_API_URL=http://${SERVER_C_HOST}:8282
 GOLD_LAKEHOUSE_TIMEOUT=120000


### PR DESCRIPTION
## Summary

CMS backend (`tazama-cms-backend`) crashloops on startup with:

```
TypeError: Configuration key "VOILA_BASE_URL" does not exist
    at ConfigService.getOrThrow
    at new VoilaProxyService
```

## Root cause

When Voila support was added (commit `4b23bb6`), the backend image was updated to call `configService.getOrThrow('VOILA_BASE_URL')` in `VoilaProxyService`. However `cms.env` only received `VOILA_URL` - the backend-specific key `VOILA_BASE_URL` was never added. `getOrThrow` (unlike `get`) throws immediately on startup if the key is absent, causing the container to crashloop.

## Fix

Added `VOILA_BASE_URL=http://tazama-cms-voila:8866` to `extensions/env/cms.env` alongside the existing `VOILA_URL`. Both point at the same internal container URL - they serve different consumers (`VOILA_URL` is used by the frontend compose env substitution; `VOILA_BASE_URL` is read directly by the backend NestJS config service).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new base URL setting for the visualization experience, improving configuration support alongside the existing visualization URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->