### PR TITLE
Align extensions Postgres with core; add AWS ops scripts and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ infra/aws/tfplan
 # OpenTofu/Terraform generated directories - never commit
 infra/aws/.terraform/
 infra/aws/.terraform.lock.hcl
+
+# Local backups (JupyterHub notebooks etc.) - binary archives, never commit
+backups/

--- a/extensions/docker-compose.extensions.infrastructure.yaml
+++ b/extensions/docker-compose.extensions.infrastructure.yaml
@@ -4,6 +4,7 @@ services:
   postgres:
     image: postgres:18
     restart: always
+    command: postgres -N 1000 -c shared_buffers=512MB -c effective_cache_size=2GB
     volumes:
       - postgres_data:/var/lib/postgresql
     healthcheck:

--- a/infra/aws/aws-deployment-instructions.md
+++ b/infra/aws/aws-deployment-instructions.md
@@ -53,8 +53,8 @@
   - [D.3 `deploy-extensions.ps1`](#d3-deploy-extensionsps1)
   - [D.4 `deploy-biar.ps1`](#d4-deploy-biarps1)
   - [D.5 `deploy-lakehouse.ps1`](#d5-deploy-lakehouseps1)
-  - [D.7 `deploy.ps1`](#d7-deployps1)
-  - [D.8 `teardown.ps1`](#d8-teardownps1)
+  - [D.6 `deploy.ps1`](#d6-deployps1)
+  - [D.7 `teardown.ps1`](#d7-teardownps1)
 - [Scripts Catalog](#scripts-catalog)
   - [`helpers.ps1`](#helpersps1)
   - [`deploy.ps1`](#deployps1)
@@ -63,8 +63,12 @@
   - [`deploy-biar.ps1`](#deploy-biarps1)
   - [`deploy-lakehouse.ps1`](#deploy-lakehouseps1)
   - [`restart-service.ps1`](#restart-serviceps1)
+  - [`restart-core-processors.ps1`](#restart-core-processorsps1)
   - [`deploy-service.ps1`](#deploy-serviceps1)
   - [OpenSearch Dashboards (Server B, internal-only)](#opensearch-dashboards-server-b-internal-only)
+  - [`check-disk-space.ps1`](#check-disk-spaceps1)
+  - [`backup-jupyter-notebooks.ps1`](#backup-jupyter-notebooksps1)
+  - [`dump-logs.ps1`](#dump-logsps1)
   - [`teardown.ps1`](#teardownps1)
   - [`add-ssh-key.ps1`](#add-ssh-keyps1)
   - [`tunnel-all.ps1`](#tunnel-allps1)
@@ -1475,10 +1479,12 @@ before moving on to the next. The runnable scripts are, in order:
 
 | Function | Purpose |
 |---|---|
-| `Get-TofuOutputs` | Runs `tofu output -json` and returns a hashtable of instance IDs and private IPs |
+| `Get-TofuOutputs` | Runs `tofu output -json` and returns a hashtable of instance IDs, private IPs, the EICE endpoint ID, and (when present) the ALB DNS name, Keycloak hostname, and demo public URL |
 | `Invoke-RemoteCommand` | SSH to an EC2 instance via EICE ProxyCommand and run a shell command |
 | `Copy-ToRemote` | SCP a file to an EC2 instance via EICE |
 | `Set-RemoteEnvOverlay` | Reads a `KEY=VALUE` overlay (from a local file via `-OverlayFile` or an inline string via `-OverlayContent`) and applies each entry to a remote `.env` using `sed` (replaces existing keys, appends missing ones). Exactly one of the two parameters must be supplied. |
+| `Set-DemoUiOverlay` | Points the tazama-demo UI at its public HTTPS URL and sources `NEXTAUTH_SECRET` from SSM into `core/.env`. No-op when no custom domain is active. |
+| `Set-ServerEnvOverlays` | Re-applies a server's full set of per-server AWS env overlays (`env-extensions.tpl` / `env-biar.tpl`, `KEYCLOAK_HOSTNAME`, `KC_HOSTNAME_PORT` strip, demo UI overlay) - used after any `git reset --hard` on the target server |
 | `Wait-Bootstrap` | Polls every 30 s until `/home/ec2-user/.bootstrap-complete` exists on the remote instance |
 
 **EICE SSH ProxyCommand used internally:**
@@ -1655,7 +1661,7 @@ The instance IAM role has a scoped read policy on the `lakehouse-staging/` prefi
 
 ---
 
-### D.7 `deploy.ps1`
+### D.6 `deploy.ps1`
 
 [infra/aws/scripts/deploy.ps1](full-stack-docker-tazama/infra/aws/scripts/deploy.ps1)
 
@@ -1677,7 +1683,7 @@ cd full-stack-docker-tazama\infra\aws\scripts
 
 ---
 
-### D.8 `teardown.ps1`
+### D.7 `teardown.ps1`
 
 [infra/aws/scripts/teardown.ps1](full-stack-docker-tazama/infra/aws/scripts/teardown.ps1)
 
@@ -1716,7 +1722,11 @@ scripts dot-source `helpers.ps1` for shared functions and constants.
 | [`deploy-biar.ps1`](#deploy-biarps1) | Server C - tazama-biar stack |
 | [`deploy-lakehouse.ps1`](#deploy-lakehouseps1) | Server C - stage and unpack Lakehouse warehouse data via S3 |
 | [`restart-service.ps1`](#restart-serviceps1) | Pull latest repo/image and recreate a single service on any server |
+| [`restart-core-processors.ps1`](#restart-core-processorsps1) | Batch wrapper - pull and recreate every core processor on Server A |
 | [`deploy-service.ps1`](#deploy-serviceps1) | Additively bring up a **new** single service without recreating existing containers |
+| [`check-disk-space.ps1`](#check-disk-spaceps1) | Report disk usage on a server and optionally prune stale Docker images |
+| [`backup-jupyter-notebooks.ps1`](#backup-jupyter-notebooksps1) | Back up all JupyterHub user notebooks from Server C to a local timestamped archive |
+| [`dump-logs.ps1`](#dump-logsps1) | Dump Docker container logs from a server (one container or all) to a local file |
 | [`teardown.ps1`](#teardownps1) | Stop all stacks across all three servers |
 | [`add-ssh-key.ps1`](#add-ssh-keyps1) | Add an SSH public key to one or more servers |
 | [`tunnel-all.ps1`](#tunnel-allps1) | Open port-forward tunnels to all three servers simultaneously |
@@ -1736,11 +1746,15 @@ Provides the following functions:
 
 | Function | Description |
 |---|---|
-| `Get-TofuOutputs` | Runs `tofu output -json` and returns a hashtable of instance IDs, private IPs, and the EICE endpoint ID |
+| `Get-TofuOutputs` | Runs `tofu output -json` and returns a hashtable of instance IDs, private IPs, the EICE endpoint ID, and (when present) the ALB DNS name, Keycloak hostname, and demo public URL |
 | `Invoke-RemoteCommand` | SSH to an EC2 instance via the EICE ProxyCommand and runs a bash command; throws on non-zero exit |
 | `Copy-ToRemote` | SCP a local file to an EC2 instance via EICE |
 | `Set-RemoteEnvOverlay` | Reads a `KEY=VALUE` overlay (from a local file via `-OverlayFile` or an inline string via `-OverlayContent`) and applies each entry to a remote `.env` file using `sed` (replaces existing keys, appends missing ones). Exactly one of the two parameters must be supplied. |
+| `Set-DemoUiOverlay` | Points the tazama-demo UI at its public HTTPS URL (`DEMO_PUBLIC_URL`) and sources `DEMO_NEXTAUTH_SECRET` from SSM into `core/.env`. No-op when no custom domain is active. Shared by deploy-core, deploy-service, and restart-service. |
+| `Set-ServerEnvOverlays` | Re-applies a server's full set of per-server AWS env overlays after a `git reset --hard` restores committed local-dev defaults: `env-extensions.tpl` (A and B), `env-biar.tpl` (C), `KEYCLOAK_HOSTNAME` injection and `KC_HOSTNAME_PORT` strip (A), and the demo UI overlay (A). |
 | `Wait-Bootstrap` | Polls an instance until the bootstrap script has written its completion marker (up to 15 min) |
+
+(`New-SshConfig` is an internal helper that writes the temporary per-connection SSH config with the EICE ProxyCommand; it is not called by other scripts directly.)
 
 Constants defined at script scope. Three of them can be overridden without editing the file by setting environment variables before running any script:
 
@@ -1756,7 +1770,9 @@ $env:TAZAMA_SSH_KEY     = "$HOME\.ssh\my_key"   # path to your EC2 SSH private k
 | `$Script:AwsRegion` | `ap-south-1` | `TAZAMA_AWS_REGION` | AWS region for all CLI calls |
 | `$Script:AwsProfile` | `tazama` | `TAZAMA_AWS_PROFILE` | AWS CLI named profile |
 | `$Script:RemoteRepo` | `/home/ec2-user/full-stack-docker-tazama` | - | Repo path on all three servers |
+| `$Script:RemoteUser` | `ec2-user` | - | SSH user on all three servers |
 | `$Script:RepoBranch` | `dev` | - | Branch pulled on each server during deploy |
+| `$Script:TemplatesDir` | `infra/aws/templates` | - | Location of the `.tpl` env overlay files |
 | `$Script:KeyFile` | `$env:USERPROFILE\.ssh\id_ed25519` | `TAZAMA_SSH_KEY` | EC2 SSH private key path |
 
 ---
@@ -1958,6 +1974,50 @@ container name, status, and image digest.
 
 ---
 
+### `restart-core-processors.ps1`
+
+[infra/aws/scripts/restart-core-processors.ps1](full-stack-docker-tazama/infra/aws/scripts/restart-core-processors.ps1)
+
+Thin batch wrapper around `restart-service.ps1`. Iterates every core processor Docker Compose service on Server A (tazama-core) and, for each one, pulls the latest image from DockerHub and recreates the container in place. No full-stack repo pull is performed (`RepoPull` stays `none`), so the code already on the server is used unchanged - only the container images are refreshed.
+
+The service list is grouped, and each group can be toggled off with a switch:
+
+| Group | Services | Skip switch |
+|---|---|---|
+| Pipeline | `ed`, `ef`, `tp`, `event-adjudicator` | always runs |
+| Rules | `rule-001` ... `rule-902` (35 rule processors, mirrors `docker-pulls.bat`) | `-SkipRules` |
+| Relays | `rsef`, `rstp`, `rsea` | `-SkipRelays` |
+| APIs | `tms`, `admin-service`, `auth-service`, `batch-ppa` | `-SkipApis` |
+| Logging | `event-sidecar`, `lumberjack` | `-SkipLogging` |
+
+```powershell
+# Refresh every core processor image on Server A
+.\restart-core-processors.ps1
+
+# See exactly what would run first
+.\restart-core-processors.ps1 -DryRun
+
+# Everything except the 35 rule processors
+.\restart-core-processors.ps1 -SkipRules
+
+# Keep going past individual failures, summarise at the end
+.\restart-core-processors.ps1 -SkipRules -SkipLogging -ContinueOnError
+```
+
+| Parameter | Description |
+|---|---|
+| `-SkipRules` | Skip the `rule-NNN` rule processors. |
+| `-SkipRelays` | Skip the relay services (`rsef`, `rstp`, `rsea`). |
+| `-SkipApis` | Skip the ingress/config/auth APIs (`tms`, `admin-service`, `auth-service`, `batch-ppa`). |
+| `-SkipLogging` | Skip the logging sidecar (`event-sidecar`, `lumberjack`). |
+| `-NoPull` | Pass-through to `restart-service.ps1`: skip the DockerHub pull and just recreate with the image already on the host. |
+| `-DryRun` | Pass-through to `restart-service.ps1`: print what would be done without making any changes on the server. |
+| `-ContinueOnError` | Keep going if a single service restart fails. By default the script stops on the first failure. A summary of failures is printed at the end regardless, and the script exits non-zero if any service failed. |
+
+> Pulling refreshed `:rc` images leaves the previously-tagged layers on disk as dangling images. After a batch refresh, run [`check-disk-space.ps1`](#check-disk-spaceps1) to see how much space they consume and reclaim it with `-Prune`.
+
+---
+
 ### `deploy-service.ps1`
 
 [infra/aws/scripts/deploy-service.ps1](full-stack-docker-tazama/infra/aws/scripts/deploy-service.ps1)
@@ -2063,6 +2123,117 @@ documents. Create the pattern once:
 
 The pattern is saved in the `.kibana_1` index on the `opensearch_data` volume,
 so it persists across container restarts.
+
+---
+
+### `check-disk-space.ps1`
+
+[infra/aws/scripts/check-disk-space.ps1](full-stack-docker-tazama/infra/aws/scripts/check-disk-space.ps1)
+
+Reports disk usage on a Tazama server and, optionally, reclaims space taken by stale Docker images left behind after image pulls. Pulling refreshed `:rc` images (e.g. via `restart-core-processors.ps1`) leaves the previously-tagged image layers on disk as dangling images; over time these fill the root volume.
+
+The script always shows three read-only reports:
+
+1. Filesystem usage (`df -h`) for the whole instance.
+2. Docker's own space accounting (`docker system df`).
+3. The list and count of dangling (untagged) images that can be reclaimed.
+
+Read-only by default - no changes are made unless `-Prune` or `-PruneAll` is given.
+
+```powershell
+# Read-only report for Server A (default)
+.\check-disk-space.ps1
+
+# Report for Server C
+.\check-disk-space.ps1 -Server C
+
+# Reclaim space from dangling images (safe)
+.\check-disk-space.ps1 -Prune
+
+# See what the aggressive prune would run without executing it
+.\check-disk-space.ps1 -PruneAll -DryRun
+```
+
+| Parameter | Description |
+|---|---|
+| `-Server` | Which EC2 instance to target: `A`, `B`, or `C`. Defaults to `A` (tazama-core). |
+| `-Prune` | Remove only **dangling** (untagged) images - safe: these have no tag and no container references them, typically the old `:rc` layers. |
+| `-PruneAll` | Remove **all** images not used by a running container (`docker image prune -a`). Aggressive: any image whose service is currently stopped is removed and must be pulled again. Overrides `-Prune`. |
+| `-DryRun` | Print the prune command that would run without executing it. The reporting still runs (it is read-only). |
+
+After a prune, the script re-runs the filesystem usage report so the reclaimed space is visible immediately.
+
+---
+
+### `backup-jupyter-notebooks.ps1`
+
+[infra/aws/scripts/backup-jupyter-notebooks.ps1](full-stack-docker-tazama/infra/aws/scripts/backup-jupyter-notebooks.ps1)
+
+Backs up all JupyterHub user workspaces from Server C to a local timestamped archive. User notebooks live in the `tazama-biar_jupyterhub_notebooks` Docker volume (mounted at `/srv/notebooks` in the `biar-jupyterhub` container), one directory per Keycloak username. The script:
+
+1. Creates a gzipped tar of the volume on Server C (`sudo` on the host, container untouched - no downtime).
+2. Downloads it via `scp` to the local backup directory.
+3. Removes the temporary archive from the server.
+
+`.ipynb_checkpoints` directories are excluded by default.
+
+```powershell
+# Default: archive to <repo>\backups\jupyter\jupyterhub-notebooks-<timestamp>.tar.gz
+.\backup-jupyter-notebooks.ps1
+
+# Custom destination, keep checkpoint files
+.\backup-jupyter-notebooks.ps1 -BackupDir D:\Backups\Tazama -IncludeCheckpoints
+```
+
+| Parameter | Description |
+|---|---|
+| `-BackupDir` | Local directory for the archive. Default: `<repo>\backups\jupyter` (gitignored - archives are binary and must never be committed). |
+| `-SshHost` | SSH host alias for Server C. Default: `tazama-c`. |
+| `-IncludeCheckpoints` | Include `.ipynb_checkpoints` directories in the archive. |
+
+To restore a single user's workspace, extract their directory from the archive and copy it back into the volume:
+
+```powershell
+tar -xzf jupyterhub-notebooks-<timestamp>.tar.gz ./<username>
+scp -r .\<username> tazama-c:/tmp/
+ssh tazama-c "sudo cp -r /tmp/<username> /var/lib/docker/volumes/tazama-biar_jupyterhub_notebooks/_data/ && rm -rf /tmp/<username>"
+```
+
+Workspace directories in the volume are owned by `root:root` (the hub spawns single-user servers as root), so `sudo cp` produces the correct ownership as-is.
+
+---
+
+### `dump-logs.ps1`
+
+[infra/aws/scripts/dump-logs.ps1](full-stack-docker-tazama/infra/aws/scripts/dump-logs.ps1)
+
+Dumps Docker container logs from a server to a local file. Connects via the EICE SSH tunnel and collects `docker logs --timestamps` output (stdout and stderr merged) for either a single named container or every running container on the server. Each container's log block is prefixed with a `Container: <name>` header, and the file starts with a capture summary (server, project, container, tail size, capture time).
+
+By default only the last 50 log lines per container are captured; use `-Tail` to adjust the count or `-All` for the complete history.
+
+```powershell
+# Last 50 lines of every running container on Server A -> aws-server-logs.txt
+.\dump-logs.ps1 -Server A
+
+# Last 50 lines of the tcs-api container on Server B
+.\dump-logs.ps1 -Server B -Container tcs-api
+
+# Full log history of the NiFi container on Server C
+.\dump-logs.ps1 -Server C -Container nifi -All
+
+# Last 200 lines of Keycloak to a custom file
+.\dump-logs.ps1 -Server A -Container keycloak -Tail 200 -OutFile keycloak.txt
+```
+
+| Parameter | Description |
+|---|---|
+| `-Server` | **Required.** `A`, `B`, or `C`. |
+| `-Container` | Name (or ID) of a single container to dump. Omit to dump every running container on the server. |
+| `-Tail` | Number of trailing log lines per container. Default: `50`. Ignored when `-All` is supplied. |
+| `-All` | Capture the entire log history for each container instead of the last `-Tail` lines. |
+| `-OutFile` | Path to the local output file. Default: `aws-server-logs.txt` in the current directory. |
+
+The script fails with an error if `-Container` names a container that does not exist on the target server. Output is read-only - nothing on the server is modified.
 
 ---
 
@@ -2390,6 +2561,33 @@ Update your Postman environment: set the base URL variable to
 | NiFi | `/nifi-api/system-diagnostics` | 200-399 |
 | JupyterHub | `/hub/health` | 200-399 |
 | All others | `/health` | 200-399 |
+
+**ALB tuning for socket.io / long-lived connections:**
+
+The module sets two non-default attributes. Both were added after a production incident (Jul 2026) where the tazama-demo UI misbehaved behind the ALB:
+
+| Attribute | Value | Why |
+|---|---|---|
+| ALB `idle_timeout` | 400s (default 60s) | The 60s default severed tazama-demo's long-lived socket.io connections, causing constant client reconnect churn and a ~30% target 4XX rate (`400 Session ID unknown` on stale reconnects). 400s comfortably exceeds socket.io's default 25s ping interval and survives long-poll cycles. |
+| `stickiness` on `tazama-tg-demo` | `lb_cookie`, 86400s | socket.io polling/websocket handshakes must hit the same target. Harmless with a single target, required the moment the service scales out. Add any new socket.io-style service to `sticky_services` in [modules/alb/main.tf](full-stack-docker-tazama/infra/aws/modules/alb/main.tf). |
+
+These are managed in the Terraform module, so a plain `tofu apply` preserves them. Do not tune them manually with `aws elbv2 modify-*` - manual changes will be reverted on the next apply.
+
+**Diagnosing similar symptoms** (UI works via SSH tunnel but misbehaves via the ALB, clients connect/disconnect every few seconds in `docker logs`):
+
+```powershell
+# Target health
+aws elbv2 describe-target-health --profile tazama --target-group-arn <tg-arn>
+
+# 4XX/5XX per target group over the last 6 hours (note: quote each
+# dimension - unquoted commas make PowerShell split them into separate args)
+aws cloudwatch get-metric-statistics --profile tazama --region ap-south-1 `
+  --namespace AWS/ApplicationELB --metric-name HTTPCode_Target_4XX_Count `
+  --dimensions "Name=LoadBalancer,Value=app/tazama-alb/<id>" "Name=TargetGroup,Value=targetgroup/tazama-tg-demo/<id>" `
+  --start-time (Get-Date).ToUniversalTime().AddHours(-6).ToString("yyyy-MM-ddTHH:mm:ssZ") `
+  --end-time (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ") `
+  --period 3600 --statistics Sum
+```
 
 **Key outputs (used by Phase G custom domain upgrade):**
 - `alb_dns_name` - DNS name for port-based access

--- a/infra/aws/modules/alb/main.tf
+++ b/infra/aws/modules/alb/main.tf
@@ -9,6 +9,11 @@ resource "aws_lb" "main" {
   security_groups    = [var.alb_sg_id]
   subnets            = var.public_subnet_ids
 
+  # Raised from the 60s default: tazama-demo holds long-lived socket.io
+  # connections and the default timeout severed them, causing constant
+  # client reconnect churn and 4XX "Session ID unknown" errors.
+  idle_timeout = 400
+
   tags = { Name = "${var.prefix}-alb" }
 }
 
@@ -64,11 +69,16 @@ locals {
     cms-api     = "/api/docs"
     trs-api     = "/api/docs"
     tcs-api     = "/api/docs"
-    voila       = "/"
+    voila       = "/voila/"
     couchdb     = "/"
     # tazama-demo (Next.js) exposes a cheap, dependency-free liveness route.
     demo        = "/api/health"
   }
+
+  # Services using socket.io (or any sticky-session protocol) need session
+  # affinity so polling/websocket handshakes keep hitting the same target
+  # if the service is ever scaled beyond one instance.
+  sticky_services = ["demo"]
 }
 
 resource "aws_lb_target_group" "services" {
@@ -90,6 +100,12 @@ resource "aws_lb_target_group" "services" {
     healthy_threshold   = 2
     unhealthy_threshold = 3
     matcher             = "200-399"
+  }
+
+  stickiness {
+    type            = "lb_cookie"
+    cookie_duration = 86400
+    enabled         = contains(local.sticky_services, each.key)
   }
 
   tags = { Name = "${var.prefix}-tg-${each.key}" }

--- a/infra/aws/scripts/backup-jupyter-notebooks.ps1
+++ b/infra/aws/scripts/backup-jupyter-notebooks.ps1
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+<#
+.SYNOPSIS
+    Backs up all JupyterHub user notebooks from Server C to a local timestamped archive.
+
+.DESCRIPTION
+    User workspaces live in the Docker volume tazama-biar_jupyterhub_notebooks
+    (mounted at /srv/notebooks in the biar-jupyterhub container). This script:
+      1. Creates a gzipped tar of the volume on Server C (requires sudo on the host).
+      2. Downloads it via scp to the local backup directory.
+      3. Removes the temporary archive from the server.
+
+    Checkpoint files (.ipynb_checkpoints) are excluded by default; pass
+    -IncludeCheckpoints to keep them.
+
+.PARAMETER BackupDir
+    Local directory to store the archive. Default: <repo>\backups\jupyter
+
+.PARAMETER SshHost
+    SSH host alias for Server C. Default: tazama-c
+
+.PARAMETER IncludeCheckpoints
+    Include .ipynb_checkpoints directories in the archive.
+
+.EXAMPLE
+    .\backup-jupyter-notebooks.ps1
+    .\backup-jupyter-notebooks.ps1 -BackupDir D:\Backups\Tazama -IncludeCheckpoints
+#>
+param(
+    [string]$BackupDir = (Join-Path $PSScriptRoot "..\..\..\backups\jupyter"),
+    [string]$SshHost = "tazama-c",
+    [switch]$IncludeCheckpoints
+)
+
+$ErrorActionPreference = "Stop"
+
+$volumePath = "/var/lib/docker/volumes/tazama-biar_jupyterhub_notebooks/_data"
+$stamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$archiveName = "jupyterhub-notebooks-$stamp.tar.gz"
+$remoteTmp = "/tmp/$archiveName"
+
+$excludeArg = if ($IncludeCheckpoints) { "" } else { "--exclude='.ipynb_checkpoints'" }
+
+New-Item -ItemType Directory -Force -Path $BackupDir | Out-Null
+$localPath = Join-Path (Resolve-Path $BackupDir) $archiveName
+
+Write-Host "Creating archive on $SshHost ..."
+ssh $SshHost "sudo tar czf $remoteTmp $excludeArg -C $volumePath . && sudo chown `$(whoami) $remoteTmp"
+if ($LASTEXITCODE -ne 0) { throw "Remote archive creation failed." }
+
+Write-Host "Downloading to $localPath ..."
+scp "${SshHost}:$remoteTmp" $localPath
+if ($LASTEXITCODE -ne 0) { throw "Download failed. Archive left on server at $remoteTmp" }
+
+Write-Host "Cleaning up remote temp file ..."
+ssh $SshHost "rm -f $remoteTmp"
+
+$size = "{0:N1} MB" -f ((Get-Item $localPath).Length / 1MB)
+Write-Host "Done: $localPath ($size)" -ForegroundColor Green

--- a/infra/aws/scripts/check-disk-space.ps1
+++ b/infra/aws/scripts/check-disk-space.ps1
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+<#
+.SYNOPSIS
+    Report disk usage on a Tazama server and, optionally, reclaim space taken by
+    stale Docker images left behind after image pulls.
+
+.DESCRIPTION
+    Pulling refreshed :rc images (e.g. via restart-core-processors.ps1) leaves the
+    previously-tagged image layers on disk as dangling images. Over time these fill
+    the root volume on Server A. This script:
+
+      1. Shows filesystem usage (df -h) for the whole instance.
+      2. Shows Docker's own space accounting (docker system df -v is summarised).
+      3. Optionally reclaims space:
+           -Prune     removes only DANGLING images (safe: images with no tag that
+                      no container references - typically the old :rc layers).
+           -PruneAll  additionally removes ALL images not used by a running
+                      container (docker image prune -a). Use with care: any image
+                      that is pulled but whose service is currently stopped will be
+                      removed and must be pulled again.
+
+    Read-only by default. No changes are made unless -Prune or -PruneAll is given.
+
+.PARAMETER Server
+    Which EC2 instance to target. One of: A, B, C. Defaults to A (tazama-core).
+
+.PARAMETER Prune
+    Remove dangling (untagged) images to reclaim space. Safe.
+
+.PARAMETER PruneAll
+    Remove all images not used by a running container. Aggressive; implies a
+    re-pull for any stopped service. Overrides -Prune.
+
+.PARAMETER DryRun
+    Print the prune command that would run without executing it. The df / docker
+    system df reporting still runs (both read-only).
+
+.EXAMPLE
+    .\check-disk-space.ps1
+    .\check-disk-space.ps1 -Prune
+    .\check-disk-space.ps1 -PruneAll -DryRun
+#>
+
+[CmdletBinding()]
+param(
+    [ValidateSet('A', 'B', 'C')]
+    [string]$Server = 'A',
+
+    [switch]$Prune,
+
+    [switch]$PruneAll,
+
+    [switch]$DryRun
+)
+
+. "$PSScriptRoot\helpers.ps1"
+
+$out = Get-TofuOutputs
+
+switch ($Server) {
+    'A' { $label = 'Server A'; $instanceId = $out.ServerA_InstanceId }
+    'B' { $label = 'Server B'; $instanceId = $out.ServerB_InstanceId }
+    'C' { $label = 'Server C'; $instanceId = $out.ServerC_InstanceId }
+}
+
+Write-Host ''
+Write-Host "=== Disk usage: $label ===" -ForegroundColor Cyan
+Write-Host ''
+
+# -- Filesystem usage -------------------------------------------------------------------------
+Write-Host "[$label] Filesystem usage (df -h):" -ForegroundColor Cyan
+Invoke-RemoteCommand -InstanceId $instanceId -Command 'df -h --total | grep -E "Filesystem|/$|overlay|/var|--total|total"'
+
+# -- Docker space accounting ------------------------------------------------------------------
+Write-Host ''
+Write-Host "[$label] Docker space (docker system df):" -ForegroundColor Cyan
+Invoke-RemoteCommand -InstanceId $instanceId -Command 'docker system df'
+
+# -- Reclaimable dangling images --------------------------------------------------------------
+Write-Host ''
+Write-Host "[$label] Dangling images (untagged, reclaimable):" -ForegroundColor Cyan
+Invoke-RemoteCommand -InstanceId $instanceId -Command 'docker images --filter "dangling=true" --format "table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.Size}}" | head -50; echo "Dangling count: $(docker images --filter "dangling=true" -q | wc -l)"'
+
+# -- Optional prune ---------------------------------------------------------------------------
+if ($Prune -or $PruneAll) {
+    $pruneCmd = if ($PruneAll) { 'docker image prune -a -f' } else { 'docker image prune -f' }
+    $desc     = if ($PruneAll) { 'ALL images not used by a running container' } else { 'dangling (untagged) images' }
+
+    Write-Host ''
+    Write-Host "[$label] Prune target: $desc" -ForegroundColor Yellow
+
+    if ($DryRun) {
+        Write-Host "[$label] [DRY RUN] Would run: $pruneCmd" -ForegroundColor Yellow
+    } else {
+        Invoke-RemoteCommand -InstanceId $instanceId -Command $pruneCmd
+
+        Write-Host ''
+        Write-Host "[$label] Filesystem usage after prune:" -ForegroundColor Green
+        Invoke-RemoteCommand -InstanceId $instanceId -Command 'df -h --total | grep -E "Filesystem|/$|overlay|--total|total"'
+    }
+} else {
+    Write-Host ''
+    Write-Host "[$label] Read-only report. Re-run with -Prune (safe, dangling only) or -PruneAll (aggressive) to reclaim space." -ForegroundColor DarkGray
+}

--- a/infra/aws/scripts/dump-logs.ps1
+++ b/infra/aws/scripts/dump-logs.ps1
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+<#
+.SYNOPSIS
+    Dump Docker container logs from an AWS server (A, B, or C) to a local file.
+
+.DESCRIPTION
+    Connects to the specified EC2 instance via the EICE SSH tunnel and collects
+    'docker logs' output for either a single container or every running
+    container on that server. The combined output is written to a local file
+    (default: aws-server-logs.txt in the current directory).
+
+    By default only the last 50 log lines per container are captured; use -All
+    to capture the complete log history instead.
+
+    When -Container is omitted, the script iterates over every running container
+    on the server and prefixes each block with a header so the sections are easy
+    to tell apart.
+
+.PARAMETER Server
+    Which EC2 instance to target. One of: A, B, C.
+    A = Server A (tazama-core)
+    B = Server B (tazama-extensions)
+    C = Server C (tazama-biar)
+
+.PARAMETER Container
+    The name (or ID) of a single container to dump logs for. When omitted, logs
+    for all running containers on the server are dumped.
+
+.PARAMETER Tail
+    Number of trailing log lines to capture per container. Default: 50.
+    Ignored when -All is supplied.
+
+.PARAMETER All
+    Capture the entire log history for each container instead of just the last
+    -Tail lines.
+
+.PARAMETER OutFile
+    Path to the output file. Default: aws-server-logs.txt in the current
+    directory.
+
+.EXAMPLE
+    .\dump-logs.ps1 -Server A
+    # Last 50 lines of every running container on Server A -> aws-server-logs.txt
+
+.EXAMPLE
+    .\dump-logs.ps1 -Server B -Container tcs-api
+    # Last 50 lines of the tcs-api container on Server B
+
+.EXAMPLE
+    .\dump-logs.ps1 -Server C -Container nifi -All
+    # Full log history of the nifi container on Server C
+
+.EXAMPLE
+    .\dump-logs.ps1 -Server A -Container keycloak -Tail 200 -OutFile keycloak.txt
+    # Last 200 lines of the keycloak container to a custom file
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet('A', 'B', 'C')]
+    [string]$Server,
+
+    [string]$Container,
+
+    [int]$Tail = 50,
+
+    [switch]$All,
+
+    [string]$OutFile = 'aws-server-logs.txt'
+)
+
+. "$PSScriptRoot\helpers.ps1"
+
+$out = Get-TofuOutputs
+
+# -- Per-server: instance ID and project label ------------------------------------------------
+switch ($Server) {
+    'A' { $label = 'Server A'; $instanceId = $out.ServerA_InstanceId; $project = 'tazama-core'       }
+    'B' { $label = 'Server B'; $instanceId = $out.ServerB_InstanceId; $project = 'tazama-extensions' }
+    'C' { $label = 'Server C'; $instanceId = $out.ServerC_InstanceId; $project = 'tazama-biar'       }
+}
+
+# 'docker logs' tail expression: 'all' captures the full history.
+$tailExpr = if ($All) { 'all' } else { "$Tail" }
+
+Write-Host ''
+Write-Host "=== Dump logs: $label ===" -ForegroundColor Cyan
+Write-Host "[$label] Instance ID: $instanceId"
+Write-Host "[$label] Project    : $project"
+Write-Host "[$label] Container  : $(if ($Container) { $Container } else { '(all running)' })"
+Write-Host "[$label] Tail       : $tailExpr"
+Write-Host "[$label] Output     : $OutFile"
+Write-Host ''
+
+# -- Build the remote log-collection script --------------------------------------------------
+# For a single container, dump its logs directly. For all containers, loop over
+# every running container name and emit a header before each block so the output
+# file is easy to navigate. --timestamps prefixes each line with an ISO time,
+# and stderr is merged into stdout so both streams are captured.
+if ($Container) {
+    $remoteCmd = @'
+set -e
+NAME="CONTAINER_PLACEHOLDER"
+if ! docker inspect "$NAME" >/dev/null 2>&1; then
+  echo "ERROR: container '$NAME' not found on this server" >&2
+  exit 1
+fi
+echo "========================================================================"
+echo "Container: $NAME"
+echo "========================================================================"
+docker logs --timestamps --tail TAIL_PLACEHOLDER "$NAME" 2>&1
+'@ -replace 'CONTAINER_PLACEHOLDER', $Container -replace 'TAIL_PLACEHOLDER', $tailExpr
+}
+else {
+    $remoteCmd = @'
+set -e
+NAMES=$(docker ps --format '{{.Names}}' | sort)
+if [ -z "$NAMES" ]; then
+  echo "No running containers on this server." >&2
+  exit 1
+fi
+for NAME in $NAMES; do
+  echo "========================================================================"
+  echo "Container: $NAME"
+  echo "========================================================================"
+  docker logs --timestamps --tail TAIL_PLACEHOLDER "$NAME" 2>&1
+  echo ""
+done
+'@ -replace 'TAIL_PLACEHOLDER', $tailExpr
+}
+
+Write-Host "[$label] Collecting logs from server..."
+
+# Capture the remote output. Invoke-RemoteCommand streams stdout back; collect
+# it into a single string for writing to the local file.
+$logs = Invoke-RemoteCommand -InstanceId $instanceId -Command $remoteCmd
+
+# Prepend a small header identifying the source and capture time.
+$header = @(
+    "# Tazama AWS container logs"
+    "# Server    : $label ($instanceId)"
+    "# Project   : $project"
+    "# Container : $(if ($Container) { $Container } else { 'all running containers' })"
+    "# Tail      : $tailExpr"
+    "# Captured  : $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss K')"
+    ""
+) -join "`n"
+
+Set-Content -Path $OutFile -Value ($header + ($logs -join "`n")) -Encoding UTF8
+
+$resolved = (Resolve-Path $OutFile).Path
+Write-Host "[$label] Logs written to $resolved" -ForegroundColor Green

--- a/infra/aws/scripts/restart-core-processors.ps1
+++ b/infra/aws/scripts/restart-core-processors.ps1
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+<#
+.SYNOPSIS
+    Restart every core Tazama processor on Server A, pulling each image from DockerHub.
+
+.DESCRIPTION
+    Thin wrapper around restart-service.ps1. Iterates the list of core processor
+    Docker Compose services on Server A (tazama-core) and, for each one, pulls the
+    latest image from DockerHub and recreates the container in place.
+
+    No full-stack-docker-tazama repo pull is performed (RepoPull stays 'none'), so
+    the code already on the server is used unchanged - only the container images are
+    refreshed from DockerHub.
+
+    Groups can be toggled with the switches below. By default every group runs.
+
+.PARAMETER SkipRules
+    Skip the rule-NNN rule processors.
+
+.PARAMETER SkipRelays
+    Skip the relay services (rsef, rstp, rsea).
+
+.PARAMETER SkipApis
+    Skip the ingress/config/auth APIs (tms, admin-service, auth-service, batch-ppa).
+
+.PARAMETER SkipLogging
+    Skip the logging sidecar (event-sidecar, lumberjack).
+
+.PARAMETER NoPull
+    Pass through to restart-service.ps1: skip the DockerHub pull and just recreate
+    with the image already on the host.
+
+.PARAMETER DryRun
+    Pass through to restart-service.ps1: print what would be done without making any
+    changes on the server.
+
+.PARAMETER ContinueOnError
+    Keep going if a single service restart fails. By default the script stops on the
+    first failure. A summary of failures is printed at the end regardless.
+
+.EXAMPLE
+    .\restart-core-processors.ps1
+    .\restart-core-processors.ps1 -DryRun
+    .\restart-core-processors.ps1 -SkipRules
+    .\restart-core-processors.ps1 -SkipRules -SkipLogging -ContinueOnError
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$SkipRules,
+    [switch]$SkipRelays,
+    [switch]$SkipApis,
+    [switch]$SkipLogging,
+    [switch]$NoPull,
+    [switch]$DryRun,
+    [switch]$ContinueOnError
+)
+
+$ErrorActionPreference = 'Stop'
+
+$restartScript = Join-Path $PSScriptRoot 'restart-service.ps1'
+if (-not (Test-Path $restartScript)) {
+    throw "Could not find restart-service.ps1 next to this script ($restartScript)."
+}
+
+# -- Core processor service names on Server A (tazama-core) -----------------------------------
+# Grouped so individual groups can be toggled off via the -Skip* switches.
+
+# Evaluation-pipeline processors (the core processors proper).
+$pipeline = @(
+    'ed',                 # event-director
+    'ef',                 # event-flow
+    'tp',                 # typology-processor
+    'event-adjudicator'
+)
+
+# Rule processors (one container per rule). Mirrors docker-pulls.bat.
+$rules = @(
+    'rule-001', 'rule-002', 'rule-003', 'rule-004', 'rule-006', 'rule-007',
+    'rule-008', 'rule-010', 'rule-011', 'rule-016', 'rule-017', 'rule-018',
+    'rule-020', 'rule-021', 'rule-024', 'rule-025', 'rule-026', 'rule-027',
+    'rule-028', 'rule-030', 'rule-044', 'rule-045', 'rule-048', 'rule-054',
+    'rule-063', 'rule-074', 'rule-075', 'rule-076', 'rule-078', 'rule-083',
+    'rule-084', 'rule-090', 'rule-091', 'rule-901', 'rule-902'
+)
+
+# Relay services.
+$relays = @(
+    'rsef',   # relay-service-ef
+    'rstp',   # relay-service-tp
+    'rsea'    # relay-service-ea
+)
+
+# Ingress / config / auth APIs.
+$apis = @(
+    'tms',            # tms-service
+    'admin-service',
+    'auth-service',
+    'batch-ppa'
+)
+
+# Logging sidecar.
+$logging = @(
+    'event-sidecar',
+    'lumberjack'
+)
+
+# -- Assemble the ordered work list -----------------------------------------------------------
+$services = @()
+$services += $pipeline
+if (-not $SkipRules)   { $services += $rules }
+if (-not $SkipRelays)  { $services += $relays }
+if (-not $SkipApis)    { $services += $apis }
+if (-not $SkipLogging) { $services += $logging }
+
+Write-Host ''
+Write-Host "=== Restart core processors on Server A ($($services.Count) services) ===" -ForegroundColor Cyan
+Write-Host "Pull from DockerHub : $(-not $NoPull)"
+Write-Host "Repo pull           : none (no full-stack repo update)"
+Write-Host "DryRun              : $([bool]$DryRun)"
+Write-Host "Services            : $($services -join ', ')"
+Write-Host ''
+
+# -- Run --------------------------------------------------------------------------------------
+$failures = @()
+$i = 0
+foreach ($svc in $services) {
+    $i++
+    Write-Host "--- [$i/$($services.Count)] $svc ---" -ForegroundColor Cyan
+
+    $splat = @{
+        Server  = 'A'
+        Service = $svc
+        # RepoPull defaults to 'none' in restart-service.ps1 - no full-stack repo pull.
+    }
+    if ($NoPull)  { $splat['NoPull']  = $true }
+    if ($DryRun)  { $splat['DryRun']  = $true }
+
+    try {
+        & $restartScript @splat
+    }
+    catch {
+        $failures += [pscustomobject]@{ Service = $svc; Error = $_.Exception.Message }
+        Write-Host "[Server A] FAILED to restart '$svc': $($_.Exception.Message)" -ForegroundColor Red
+        if (-not $ContinueOnError) {
+            Write-Host ''
+            Write-Host "Stopping on first failure. Re-run with -ContinueOnError to process the rest." -ForegroundColor Yellow
+            break
+        }
+    }
+}
+
+# -- Summary ----------------------------------------------------------------------------------
+Write-Host ''
+Write-Host '=== Summary ===' -ForegroundColor Cyan
+if ($failures.Count -eq 0) {
+    Write-Host "All $($services.Count) core processor restarts completed." -ForegroundColor Green
+} else {
+    Write-Host "$($failures.Count) of $($services.Count) service(s) failed:" -ForegroundColor Red
+    $failures | ForEach-Object { Write-Host "  - $($_.Service): $($_.Error)" -ForegroundColor Red }
+    exit 1
+}


### PR DESCRIPTION
## Summary

Aligns the extensions Postgres deployment with core, adds a set of AWS operations scripts, and reconciles the deployment documentation with the current script set.

## Changes

### Postgres (extensions)
- Raised the extensions Postgres instance to **1000 max connections** with `shared_buffers=512MB` and `effective_cache_size=2GB`, applied via the `postgres` command flags so the settings actually take effect (the official image ignores the `POSTGRES_*` env vars). This matches the tuning already present on the core deployment.

### ALB (infra)
- Raised `idle_timeout` to 400s to stop socket.io connection churn on `tazama-demo`.
- Enabled `lb_cookie` stickiness (24h) on the `demo` target group.
- Fixed the `voila` health check path to `/voila/`.

### Ops scripts (new)
- `dump-logs.ps1` - dump Docker container logs (one container or all) from a server to a local file.
- `check-disk-space.ps1` - report disk usage and optionally prune stale Docker images.
- `restart-core-processors.ps1` - batch-refresh every core processor image on Server A.
- `backup-jupyter-notebooks.ps1` - back up JupyterHub user notebooks from Server C.

### Docs
- Documented `dump-logs.ps1` in the scripts catalog.
- Reconciled the scripts catalog and `helpers.ps1` function tables with the current scripts (added `Set-DemoUiOverlay`, `Set-ServerEnvOverlays`, missing constants, and updated `Get-TofuOutputs`).
- Renumbered Phase D sections so they run sequentially (D.1-D.7).

### Misc
- `.gitignore`: ignore local `backups/` archives.

## Testing
- Documentation-only and infra config changes; no runtime code paths altered. Postgres tuning takes effect after recreating the extensions `postgres` container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tools to restart core processing services, check and clean disk usage, back up Jupyter notebooks, and collect container logs.
  - Added options for dry runs, selective service restarts, checkpoint inclusion, log filtering, and controlled cleanup.

- **Improvements**
  - Improved connection stability for long-lived sessions and enabled session affinity for demo traffic.
  - Updated PostgreSQL settings to support higher connection capacity.

- **Documentation**
  - Expanded deployment guidance, script references, troubleshooting instructions, and infrastructure output documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->