### PR TITLE
chore: align launcher shell scripts with batch counterparts

### DIFF
--- a/biar/tazama-biar.sh
+++ b/biar/tazama-biar.sh
@@ -9,15 +9,33 @@ pause() {
     read -rp " Press Enter to continue..."
 }
 
+# Verify tazama-core is reachable via its NATS exterior port (14222).
+# SERVER_A_HOST defaults to localhost for single-machine; set to the private
+# IP in .env for AWS multi-host deployments.
 check_core_reachable() {
     local server_a_host="localhost"
 
     if [[ -f ./.env ]]; then
         local env_host
-        env_host=$(grep -E '^SERVER_A_HOST=' ./.env | cut -d'=' -f2- | tr -d '"' | tr -d "'" | tr -d '\r')
+        env_host=$(grep -E '^SERVER_A_HOST=' ./.env | head -n1 | cut -d'=' -f2- | tr -d '"' | tr -d "'" | tr -d '\r')
         if [[ -n "$env_host" ]]; then
             server_a_host="$env_host"
         fi
+    fi
+
+    if command -v nc >/dev/null 2>&1; then
+        nc -z -w 3 "$server_a_host" 14222 >/dev/null 2>&1
+    else
+        timeout 3 bash -c ">/dev/tcp/${server_a_host}/14222" >/dev/null 2>&1
+    fi
+
+    if [[ $? -ne 0 ]]; then
+        echo ""
+        echo " ERROR: tazama-core is not reachable at ${server_a_host}:14222"
+        echo "        Ensure tazama-core is running and SERVER_A_HOST is set correctly in .env"
+        echo ""
+        pause
+        return 1
     fi
     return 0
 }

--- a/core/tazama-core.sh
+++ b/core/tazama-core.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# filepath: ./tazama.sh
+# filepath: ./tazama-core.sh
 
-set -e
+cd "$(dirname "$0")"
 
 # Color codes for output
 RED='\033[0;31m'
@@ -18,14 +18,11 @@ print_color() {
     echo -e "${color}$@${NC}"
 }
 
-# Initialize variables
-volumes="[ ]"
+# Addon state (reset on each return to the main menu)
 auth="[ ]"
 basiclogs="[ ]"
 relay="[ ]"
-ui="[ ]"
 natsutils="[ ]"
-batchppa="[ ]"
 # These options default to enabled
 pgadmin="[X]"
 hasura="[X]"
@@ -38,12 +35,22 @@ IS_MULTITENANT_DEPLOYMENT=0
 toggle_addon() {
     local addon_name=$1
     local current_value="${!addon_name}"
-    
+
     if [[ "$current_value" == "[ ]" ]]; then
         eval "$addon_name='[X]'"
     else
         eval "$addon_name='[ ]'"
     fi
+}
+
+# Reset addon selection back to defaults
+reset_addons() {
+    auth="[ ]"
+    basiclogs="[ ]"
+    relay="[ ]"
+    natsutils="[ ]"
+    pgadmin="[X]"
+    hasura="[X]"
 }
 
 # Main menu
@@ -74,24 +81,20 @@ show_addons_menu() {
     echo "1. $auth Authentication"
     echo "2. $relay Relay services (NATS)"
     echo "3. $basiclogs Basic Logs"
-    if [[ $IS_MULTITENANT_DEPLOYMENT -ne 1 ]]; then
-        echo "4. $ui Demo UI"
-    fi
     echo ""
     print_color $CYAN "UTILITY ADDONS:"
     echo ""
-    echo "5. $natsutils NATS Utilities"
-    echo "6. $batchppa Batch PPA"
-    echo "7. $pgadmin pgAdmin for PostgreSQL"
-    echo "8. $hasura Hasura GraphQL API for PostgreSQL"
+    echo "4. $natsutils NATS Utilities"
+    echo "5. $pgadmin pgAdmin for PostgreSQL"
+    echo "6. $hasura Hasura GraphQL API for PostgreSQL"
     echo ""
-    echo "Toggle addons (1-8), (a)pply current selection, (r)eturn, or (q)uit"
+    echo "Toggle addons (1-6), (a)pply current selection, (r)eturn, or (q)uit"
 }
 
 # Build docker compose command
 build_docker_command() {
     local cmd="docker compose -f docker-compose.base.infrastructure.yaml -f docker-compose.base.override.yaml"
-    
+
     # Add core processors and configuration
     if [[ $IS_GITHUB_DEPLOYMENT -eq 1 ]]; then
         cmd="$cmd -f docker-compose.dev.cfg.yaml -f docker-compose.dev.core.yaml"
@@ -103,16 +106,16 @@ build_docker_command() {
         else
             cmd="$cmd -f docker-compose.hub.cfg.yaml"
         fi
-        
+
         cmd="$cmd -f docker-compose.hub.core.yaml"
-        
+
         if [[ $IS_FULL_DEPLOYMENT -eq 1 ]]; then
             cmd="$cmd -f docker-compose.full.rules.yaml"
         else
             cmd="$cmd -f docker-compose.hub.rules.yaml"
         fi
     fi
-    
+
     # Add authentication services
     if [[ "$auth" == "[X]" ]]; then
         cmd="$cmd -f docker-compose.base.auth.yaml"
@@ -120,7 +123,7 @@ build_docker_command() {
             cmd="$cmd -f docker-compose.dev.auth.yaml"
         fi
     fi
-    
+
     # Add relay services
     if [[ "$relay" == "[X]" ]]; then
         if [[ $IS_GITHUB_DEPLOYMENT -eq 1 ]]; then
@@ -131,7 +134,7 @@ build_docker_command() {
             cmd="$cmd -f docker-compose.hub.relay.yaml"
         fi
     fi
-    
+
     # Add basic logging
     if [[ "$basiclogs" == "[X]" ]]; then
         if [[ $IS_GITHUB_DEPLOYMENT -eq 1 ]]; then
@@ -140,38 +143,39 @@ build_docker_command() {
             cmd="$cmd -f docker-compose.hub.logs.base.yaml"
         fi
     fi
-    
+
     # Add utility addons
-    [[ "$ui" == "[X]" ]] && cmd="$cmd -f docker-compose.hub.ui.yaml"
     [[ "$natsutils" == "[X]" ]] && cmd="$cmd -f docker-compose.utils.nats-utils.yaml"
-    [[ "$batchppa" == "[X]" ]] && cmd="$cmd -f docker-compose.utils.batch-ppa.yaml"
     [[ "$pgadmin" == "[X]" ]] && cmd="$cmd -f docker-compose.utils.pgadmin.yaml"
     [[ "$hasura" == "[X]" ]] && cmd="$cmd -f docker-compose.utils.hasura.yaml"
-    
+
     echo "$cmd"
 }
 
 # Apply configuration and deploy
 apply_configuration() {
-    local cmd=$(build_docker_command)
-    
+    local cmd
+    cmd=$(build_docker_command)
+
     echo ""
-    print_color $YELLOW "Command to run: $cmd -p tazama up -d"
+    print_color $YELLOW "Command to run: $cmd -p tazama-core up -d"
     echo ""
     read -p "Press (e) to execute, (q) to quit or any other key to go back: " confirm
     echo ""
-    
+
     if [[ "$confirm" == "e" || "$confirm" == "E" ]]; then
         print_color $GREEN "Stopping existing Tazama containers..."
         echo ""
-        docker compose -p tazama down --volumes --remove-orphans
+        docker compose -p tazama-biar down --volumes --remove-orphans 2>/dev/null || true
+        docker compose -p tazama-extensions down --volumes --remove-orphans 2>/dev/null || true
+        docker compose -p tazama-core down --volumes --remove-orphans
         echo ""
-        print_color $GREEN "Deploying Tazama..."
+        print_color $GREEN "Deploying Tazama from Docker Hub..."
         echo ""
-        $cmd -p tazama up -d --remove-orphans --force-recreate
-        
+        $cmd -p tazama-core up -d --remove-orphans --force-recreate
+
         echo ""
-        print_color $GREEN "✓ Deployment complete!"
+        print_color $GREEN "Deployment complete!"
         echo ""
         read -p "Press Enter to continue..."
         return 0
@@ -180,6 +184,48 @@ apply_configuration() {
     else
         return 1
     fi
+}
+
+# Addons selection loop (shared by all deployment types)
+run_addons_loop() {
+    while true; do
+        show_addons_menu
+        read -p "Enter your choice: " choice
+
+        case $choice in
+            a|A)
+                if apply_configuration; then
+                    return 0
+                fi
+                ;;
+            r|R) return 0 ;;
+            q|Q) exit 0 ;;
+            1)
+                if [[ $IS_MULTITENANT_DEPLOYMENT -eq 1 ]]; then
+                    print_color $YELLOW "Auth and Relay are mandatory for multitenant deployment"
+                    sleep 1
+                else
+                    toggle_addon "auth"
+                fi
+                ;;
+            2)
+                if [[ $IS_MULTITENANT_DEPLOYMENT -eq 1 ]]; then
+                    print_color $YELLOW "Auth and Relay are mandatory for multitenant deployment"
+                    sleep 1
+                else
+                    toggle_addon "relay"
+                fi
+                ;;
+            3) toggle_addon "basiclogs" ;;
+            4) toggle_addon "natsutils" ;;
+            5) toggle_addon "pgadmin" ;;
+            6) toggle_addon "hasura" ;;
+            *)
+                print_color $RED "Invalid choice."
+                sleep 1
+                ;;
+        esac
+    done
 }
 
 # Docker utilities menu
@@ -199,6 +245,44 @@ show_utils_menu() {
     echo "Select function (1-7), (r)eturn or (q)uit"
 }
 
+docker_utils() {
+    while true; do
+        show_utils_menu
+        read -p "Enter your choice: " choice
+
+        case $choice in
+            r|R) return 0 ;;
+            q|Q) exit 0 ;;
+            1)
+                print_color $GREEN "Restarting ED, TP and EA..."
+                docker restart tazama-core-tp-1 tazama-core-event-adjudicator-1 tazama-core-ed-1
+                ;;
+            2)
+                print_color $YELLOW "Stopping and removing Tazama containers and volumes..."
+                docker compose -p tazama-biar down --volumes 2>/dev/null || true
+                docker compose -p tazama-extensions down --volumes 2>/dev/null || true
+                docker compose -p tazama-core down --volumes
+                ;;
+            3)
+                print_color $YELLOW "Removing all unused Docker resources..."
+                docker system prune -a -f --volumes
+                ;;
+            4) docker image ls ;;
+            5) docker container ls ;;
+            6) docker volume ls ;;
+            7) docker network ls ;;
+            *)
+                print_color $RED "Invalid choice."
+                sleep 1
+                continue
+                ;;
+        esac
+
+        echo ""
+        read -p "Press Enter to continue..."
+    done
+}
+
 # Database utilities menu
 show_dbutils_menu() {
     clear
@@ -213,13 +297,68 @@ show_dbutils_menu() {
     echo "Select function (1-4), (r)eturn or (q)uit"
 }
 
+database_utils() {
+    while true; do
+        show_dbutils_menu
+        read -p "Enter your choice: " choice
+
+        case $choice in
+            r|R) return 0 ;;
+            q|Q) exit 0 ;;
+            1)
+                print_color $GREEN "Listing PostgreSQL databases..."
+                docker exec -it tazama-core-postgres-1 psql -U postgres -c "\l"
+                ;;
+            2)
+                print_color $GREEN "Listing PostgreSQL tables..."
+                for db in event_history raw_history configuration evaluation; do
+                    echo ""
+                    print_color $CYAN "=== $db ==="
+                    docker exec -it tazama-core-postgres-1 psql -U postgres -d $db -c "\dt" 2>/dev/null || echo "  (database not found)"
+                done
+                ;;
+            3)
+                echo ""
+                print_color $YELLOW "WARNING: This will reset all Hasura metadata!"
+                read -p "Continue? (y/n): " confirm
+
+                if [[ "$confirm" == "y" || "$confirm" == "Y" ]]; then
+                    print_color $GREEN "Stopping Hasura containers..."
+                    docker stop tazama-core-hasura-1 tazama-core-hasura-init-1 2>/dev/null || true
+
+                    print_color $GREEN "Removing Hasura containers..."
+                    docker rm tazama-core-hasura-1 tazama-core-hasura-init-1 2>/dev/null || true
+
+                    print_color $GREEN "Dropping Hasura metadata database..."
+                    docker exec tazama-core-postgres-1 psql -U postgres -c "DROP DATABASE IF EXISTS hasura;"
+                    docker exec tazama-core-postgres-1 psql -U postgres -c "CREATE DATABASE hasura;"
+
+                    print_color $GREEN "Hasura metadata reset complete!"
+                fi
+                ;;
+            4)
+                print_color $GREEN "Reinitializing Hasura..."
+                docker restart tazama-core-hasura-init-1
+                ;;
+            *)
+                print_color $RED "Invalid choice."
+                sleep 1
+                continue
+                ;;
+        esac
+
+        echo ""
+        read -p "Press Enter to continue..."
+    done
+}
+
 # Consoles menu
 show_consoles_menu() {
     clear
     echo ""
     print_color $BLUE "Access a service web console:"
     echo ""
-    echo "1. pgAdmin - localhost:15050"
+    echo "1. pgAdmin - localhost:5050"
     echo "2. Hasura - localhost:6100"
     echo "3. Keycloak - localhost:8080"
     echo "4. TMS-service Swagger - localhost:5000/documentation"
@@ -231,7 +370,7 @@ show_consoles_menu() {
 # Open URL based on OS
 open_url() {
     local url=$1
-    
+
     if command -v xdg-open &> /dev/null; then
         xdg-open "$url" 2>/dev/null
     elif command -v open &> /dev/null; then
@@ -241,160 +380,73 @@ open_url() {
     fi
 }
 
+consoles() {
+    while true; do
+        show_consoles_menu
+        read -p "Enter your choice: " choice
+
+        case $choice in
+            r|R) return 0 ;;
+            q|Q) exit 0 ;;
+            1)
+                print_color $GREEN "Opening pgAdmin..."
+                open_url "http://localhost:5050"
+                ;;
+            2)
+                print_color $GREEN "Opening Hasura..."
+                open_url "http://localhost:6100"
+                ;;
+            3)
+                print_color $GREEN "Opening Keycloak..."
+                open_url "http://localhost:8080"
+                ;;
+            4)
+                print_color $GREEN "Opening TMS-service Swagger..."
+                open_url "http://localhost:5000/documentation"
+                ;;
+            5)
+                print_color $GREEN "Opening Admin-service Swagger..."
+                open_url "http://localhost:5100/documentation"
+                ;;
+            *)
+                print_color $RED "Invalid choice."
+                sleep 1
+                continue
+                ;;
+        esac
+
+        echo ""
+        read -p "Press Enter to continue..."
+    done
+}
+
 # Main loop
 while true; do
+    reset_addons
     show_main_menu
     read -p "Enter your choice: " type
-    
+
     case $type in
         1)
             IS_GITHUB_DEPLOYMENT=1
             IS_FULL_DEPLOYMENT=0
             IS_MULTITENANT_DEPLOYMENT=0
             relay="[X]"
-            
-            # Addons loop
-            while true; do
-                show_addons_menu
-                read -p "Enter your choice: " choice
-                
-                case $choice in
-                    a|A)
-                        if apply_configuration; then
-                            break
-                        fi
-                        ;;
-                    r|R)
-                        break
-                        ;;
-                    q|Q)
-                        exit 0
-                        ;;
-                    1)
-                        [[ $IS_MULTITENANT_DEPLOYMENT -ne 1 ]] && toggle_addon "auth"
-                        ;;
-                    2)
-                        [[ $IS_MULTITENANT_DEPLOYMENT -ne 1 ]] && toggle_addon "relay"
-                        ;;
-                    3) toggle_addon "basiclogs" ;;
-                    4) 
-                        if [[ $IS_MULTITENANT_DEPLOYMENT -ne 1 ]]; then
-                            if [[ "$ui" == "[ ]" ]]; then
-                                ui="[X]"
-                                auth="[ ]"
-                                relay="[ ]"
-                                echo ""
-                                print_color $YELLOW "Note: Enabling the Demo UI addon will disable Authentication and Relay services."
-                                print_color $YELLOW "You can re-enable these services again, but the Demo UI will not function correctly."
-                                echo ""
-                                read -p "Press any key to continue..."
-                            else
-                                ui="[ ]"
-                            fi
-                        fi
-                        ;;
-                    5) toggle_addon "natsutils" ;;
-                    6) toggle_addon "batchppa" ;;
-                    7) toggle_addon "pgadmin" ;;
-                    8) toggle_addon "hasura" ;;
-                    *)
-                        print_color $RED "Invalid choice."
-                        sleep 1
-                        ;;
-                esac
-            done
+            run_addons_loop
             ;;
         2)
             IS_GITHUB_DEPLOYMENT=0
             IS_FULL_DEPLOYMENT=0
             IS_MULTITENANT_DEPLOYMENT=0
             relay="[X]"
-            
-            while true; do
-                show_addons_menu
-                read -p "Enter your choice: " choice
-                
-                case $choice in
-                    a|A)
-                        if apply_configuration; then
-                            break
-                        fi
-                        ;;
-                    r|R) break ;;
-                    q|Q) exit 0 ;;
-                    1) toggle_addon "auth" ;;
-                    2) toggle_addon "relay" ;;
-                    3) toggle_addon "basiclogs" ;;
-                    4) 
-                        if [[ "$ui" == "[ ]" ]]; then
-                            ui="[X]"
-                            auth="[ ]"
-                            relay="[ ]"
-                            echo ""
-                            print_color $YELLOW "Note: Enabling the Demo UI addon will disable Authentication and Relay services."
-                            print_color $YELLOW "You can re-enable these services again, but the Demo UI will not function correctly."
-                            echo ""
-                            read -p "Press any key to continue..."
-                        else
-                            ui="[ ]"
-                        fi
-                        ;;
-                    5) toggle_addon "natsutils" ;;
-                    6) toggle_addon "batchppa" ;;
-                    7) toggle_addon "pgadmin" ;;
-                    8) toggle_addon "hasura" ;;
-                    *)
-                        print_color $RED "Invalid choice."
-                        sleep 1
-                        ;;
-                esac
-            done
+            run_addons_loop
             ;;
         3)
             IS_GITHUB_DEPLOYMENT=0
             IS_FULL_DEPLOYMENT=1
             IS_MULTITENANT_DEPLOYMENT=0
             relay="[X]"
-            
-            while true; do
-                show_addons_menu
-                read -p "Enter your choice: " choice
-                
-                case $choice in
-                    a|A)
-                        if apply_configuration; then
-                            break
-                        fi
-                        ;;
-                    r|R) break ;;
-                    q|Q) exit 0 ;;
-                    1) toggle_addon "auth" ;;
-                    2) toggle_addon "relay" ;;
-                    3) toggle_addon "basiclogs" ;;
-                    4) 
-                        if [[ "$ui" == "[ ]" ]]; then
-                            ui="[X]"
-                            auth="[ ]"
-                            relay="[ ]"
-                            echo ""
-                            print_color $YELLOW "Note: Enabling the Demo UI addon will disable Authentication and Relay services."
-                            print_color $YELLOW "You can re-enable these services again, but the Demo UI will not function correctly."
-                            echo ""
-                            read -p "Press any key to continue..."
-                        else
-                            ui="[ ]"
-                        fi
-                        ;;
-                    5) toggle_addon "natsutils" ;;
-                    6) toggle_addon "batchppa" ;;
-                    7) toggle_addon "pgadmin" ;;
-                    8) toggle_addon "hasura" ;;
-                    *)
-                        print_color $RED "Invalid choice."
-                        sleep 1
-                        ;;
-                esac
-            done
+            run_addons_loop
             ;;
         4)
             IS_GITHUB_DEPLOYMENT=0
@@ -402,178 +454,11 @@ while true; do
             IS_MULTITENANT_DEPLOYMENT=1
             auth="[X]"
             relay="[X]"
-            
-            while true; do
-                show_addons_menu
-                read -p "Enter your choice: " choice
-                
-                case $choice in
-                    a|A)
-                        if apply_configuration; then
-                            break
-                        fi
-                        ;;
-                    r|R) break ;;
-                    q|Q) exit 0 ;;
-                    1|2)
-                        print_color $YELLOW "Auth and Relay are mandatory for multitenant deployment"
-                        sleep 1
-                        ;;
-                    3) toggle_addon "basiclogs" ;;
-                    4)
-                        print_color $YELLOW "Demo UI is not available for multitenant deployment"
-                        sleep 1
-                        ;;
-                    5) toggle_addon "natsutils" ;;
-                    6) toggle_addon "batchppa" ;;
-                    7) toggle_addon "pgadmin" ;;
-                    8) toggle_addon "hasura" ;;
-                    *)
-                        print_color $RED "Invalid choice."
-                        sleep 1
-                        ;;
-                esac
-            done
+            run_addons_loop
             ;;
-        5)
-            # Docker utilities
-            while true; do
-                show_utils_menu
-                read -p "Enter your choice: " choice
-                
-                case $choice in
-                    r|R) break ;;
-                    q|Q) exit 0 ;;
-                    1)
-                        print_color $GREEN "Restarting ED, TP and EA..."
-                        docker restart tazama-tp-1 tazama-event-adjudicator-1 tazama-ed-1
-                        ;;
-                    2)
-                        print_color $YELLOW "Stopping and removing Tazama containers and volumes..."
-                        docker compose -p tazama down --volumes
-                        ;;
-                    3)
-                        print_color $YELLOW "Removing all unused Docker resources..."
-                        docker system prune -a -f --volumes
-                        ;;
-                    4)
-                        docker image ls
-                        ;;
-                    5)
-                        docker container ls
-                        ;;
-                    6)
-                        docker volume ls
-                        ;;
-                    7)
-                        docker network ls
-                        ;;
-                    *)
-                        print_color $RED "Invalid choice."
-                        sleep 1
-                        continue
-                        ;;
-                esac
-                
-                echo ""
-                read -p "Press Enter to continue..."
-            done
-            ;;
-        6)
-            # Database utilities
-            while true; do
-                show_dbutils_menu
-                read -p "Enter your choice: " choice
-                
-                case $choice in
-                    r|R) break ;;
-                    q|Q) exit 0 ;;
-                    1)
-                        print_color $GREEN "Listing PostgreSQL databases..."
-                        docker exec -it tazama-postgres-1 psql -U postgres -c "\l"
-                        ;;
-                    2)
-                        print_color $GREEN "Listing PostgreSQL tables..."
-                        for db in event_history raw_history configuration evaluation; do
-                            echo ""
-                            print_color $CYAN "=== $db ==="
-                            docker exec -it tazama-postgres-1 psql -U postgres -d $db -c "\dt" 2>/dev/null || echo "  (database not found)"
-                        done
-                        ;;
-                    3)
-                        echo ""
-                        print_color $YELLOW "WARNING: This will reset all Hasura metadata!"
-                        read -p "Continue? (y/n): " confirm
-                        
-                        if [[ "$confirm" == "y" || "$confirm" == "Y" ]]; then
-                            print_color $GREEN "Stopping Hasura containers..."
-                            docker stop tazama-hasura-1 tazama-hasura-init-1 2>/dev/null || true
-                            
-                            print_color $GREEN "Removing Hasura containers..."
-                            docker rm tazama-hasura-1 tazama-hasura-init-1 2>/dev/null || true
-                            
-                            print_color $GREEN "Dropping Hasura metadata database..."
-                            docker exec tazama-postgres-1 psql -U postgres -c "DROP DATABASE IF EXISTS hasura;"
-                            docker exec tazama-postgres-1 psql -U postgres -c "CREATE DATABASE hasura;"
-                            
-                            print_color $GREEN "✓ Hasura metadata reset complete!"
-                        fi
-                        ;;
-                    4)
-                        print_color $GREEN "Reinitializing Hasura..."
-                        docker restart tazama-hasura-init-1
-                        ;;
-                    *)
-                        print_color $RED "Invalid choice."
-                        sleep 1
-                        continue
-                        ;;
-                esac
-                
-                echo ""
-                read -p "Press Enter to continue..."
-            done
-            ;;
-        7)
-            # Consoles
-            while true; do
-                show_consoles_menu
-                read -p "Enter your choice: " choice
-                
-                case $choice in
-                    r|R) break ;;
-                    q|Q) exit 0 ;;
-                    1)
-                        print_color $GREEN "Opening pgAdmin..."
-                        open_url "http://localhost:15050"
-                        ;;
-                    2)
-                        print_color $GREEN "Opening Hasura..."
-                        open_url "http://localhost:6100"
-                        ;;
-                    3)
-                        print_color $GREEN "Opening Keycloak..."
-                        open_url "http://localhost:8080"
-                        ;;
-                    4)
-                        print_color $GREEN "Opening TMS-service Swagger..."
-                        open_url "http://localhost:5000/documentation"
-                        ;;
-                    5)
-                        print_color $GREEN "Opening Admin-service Swagger..."
-                        open_url "http://localhost:5100/documentation"
-                        ;;
-                    *)
-                        print_color $RED "Invalid choice."
-                        sleep 1
-                        continue
-                        ;;
-                esac
-                
-                echo ""
-                read -p "Press Enter to continue..."
-            done
-            ;;
+        5) docker_utils ;;
+        6) database_utils ;;
+        7) consoles ;;
         q|Q)
             print_color $GREEN "Exiting..."
             exit 0

--- a/extensions/tazama-extensions.sh
+++ b/extensions/tazama-extensions.sh
@@ -1,777 +1,206 @@
 #!/bin/bash
-# filepath: ./tazama.sh
+# filepath: ./tazama-extensions.sh
 
-set -e
+cd "$(dirname "$0")"
 
-# Color codes for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-NC='\033[0m' # No Color
+CORE_PROJECT="tazama-core"
+EXTENSIONS_PROJECT="tazama-extensions"
 
-# Function to print colored output
-print_color() {
-    local color=$1
-    shift
-    echo -e "${color}$@${NC}"
+pause() {
+    read -rp " Press Enter to continue..."
 }
 
-# Initialize variables
-volumes="[ ]"
-auth="[ ]"
-basiclogs="[ ]"
-relay="[ ]"
-ui="[ ]"
-natsutils="[ ]"
-batchppa="[ ]"
-cms="[ ]"
-trs="[ ]"
-tcs="[ ]"
-deapi_dems="[ ]"
-opensearch="[ ]"
-# These options default to enabled
-pgadmin="[X]"
-hasura="[X]"
+# ---------------------------------------------------------------
+# Server A pre-flight: DEMS + DEAPI
+# ---------------------------------------------------------------
+deploy_apis() {
+    local api_build=$1
 
-IS_GITHUB_DEPLOYMENT=0
-IS_FULL_DEPLOYMENT=0
-IS_MULTITENANT_DEPLOYMENT=0
-
-# Extended addons are available in GitHub and Public (DockerHub) deployments.
-is_extended_addons_deployment() {
-    [[ $IS_GITHUB_DEPLOYMENT -eq 1 || ( $IS_FULL_DEPLOYMENT -eq 0 && $IS_MULTITENANT_DEPLOYMENT -eq 0 ) ]]
-}
-
-# Function to toggle addon
-toggle_addon() {
-    local addon_name=$1
-    local current_value="${!addon_name}"
-    
-    if [[ "$current_value" == "[ ]" ]]; then
-        eval "$addon_name='[X]'"
-    else
-        eval "$addon_name='[ ]'"
-    fi
-}
-
-# Auth is required for selected extended addons
-has_auth_required_addons_enabled() {
-    [[ "$cms" == "[X]" || "$trs" == "[X]" || "$tcs" == "[X]" || "$deapi_dems" == "[X]" || "$opensearch" == "[X]" ]]
-}
-
-# OpenSearch is required for selected extended addons
-has_opensearch_required_addons_enabled() {
-    [[ "$cms" == "[X]" || "$trs" == "[X]" || "$tcs" == "[X]" ]]
-}
-
-# Main menu
-show_main_menu() {
-    clear
-    echo ""
-    print_color $BLUE "Select docker deployment type:"
-    echo ""
-    echo "1. Public (GitHub)"
-    echo "2. Public (DockerHub)"
-    echo "3. Full-service (DockerHub)"
-    echo "4. Multi-Tenant Public (DockerHub)"
-    echo "5. Docker Utilities"
-    echo "6. Database Utilities"
-    echo "7. Consoles"
-    echo ""
-    echo "Select option (1-7), or (q)uit:"
-}
-
-# Addons menu
-show_addons_menu() {
-    clear
-    echo ""
-    print_color $BLUE "Enable optional deployment configuration addons:"
-    echo ""
-    print_color $CYAN "CORE ADDONS:"
-    echo ""
-    echo "1. $auth Authentication"
-    echo "2. $relay Relay services (NATS)"
-    echo "3. $basiclogs Basic Logs"
-    if [[ $IS_MULTITENANT_DEPLOYMENT -ne 1 ]]; then
-        echo "4. $ui Demo UI"
-    fi
-    echo ""
-    print_color $CYAN "UTILITY ADDONS:"
-    echo ""
-    echo "5. $natsutils NATS Utilities"
-    echo "6. $batchppa Batch PPA"
-    echo "7. $pgadmin pgAdmin for PostgreSQL"
-    echo "8. $hasura Hasura GraphQL API for PostgreSQL"
-    if is_extended_addons_deployment; then
+    local running
+    running=$(docker compose -p "$CORE_PROJECT" ps --status running -q 2>/dev/null)
+    if [[ -z "$running" ]]; then
         echo ""
-        print_color $CYAN "EXTENDED ADDONS (AUTH REQUIRED):"
+        echo " ERROR: tazama-core is not running."
+        echo "        Start tazama-core.sh on this machine first, then retry."
         echo ""
-        echo "9.  $cms CMS"
-        echo "10. $trs TRS"
-        echo "11. $tcs TCS"
-        echo "12. $deapi_dems DEAPI & DEMS"
-        echo "13. $opensearch OpenSearch"
-    fi
-    echo ""
-    if is_extended_addons_deployment; then
-        echo "Toggle addons (1-13), (a)pply current selection, (r)eturn, or (q)uit"
-    else
-        echo "Toggle addons (1-8), (a)pply current selection, (r)eturn, or (q)uit"
-    fi
-}
-
-# Build docker compose command
-build_docker_command() {
-    local cmd="docker compose -f docker-compose.base.infrastructure.yaml -f docker-compose.base.override.yaml"
-    
-    # Add core processors and configuration
-    if [[ $IS_GITHUB_DEPLOYMENT -eq 1 ]]; then
-        cmd="$cmd -f docker-compose.dev.cfg.yaml -f docker-compose.dev.core.yaml"
-    else
-        if [[ $IS_MULTITENANT_DEPLOYMENT -eq 1 ]]; then
-            cmd="$cmd -f docker-compose.multitenant.cfg.yaml"
-        elif [[ $IS_FULL_DEPLOYMENT -eq 1 ]]; then
-            cmd="$cmd -f docker-compose.full.cfg.yaml"
-        else
-            cmd="$cmd -f docker-compose.hub.cfg.yaml"
-        fi
-        
-        cmd="$cmd -f docker-compose.hub.core.yaml"
-        
-        if [[ $IS_FULL_DEPLOYMENT -eq 1 ]]; then
-            cmd="$cmd -f docker-compose.full.rules.yaml"
-        else
-            cmd="$cmd -f docker-compose.hub.rules.yaml"
-        fi
-    fi
-    
-    # Add authentication services
-    if [[ "$auth" == "[X]" ]]; then
-        cmd="$cmd -f docker-compose.base.auth.yaml"
-        if [[ $IS_GITHUB_DEPLOYMENT -eq 1 ]]; then
-            cmd="$cmd -f docker-compose.dev.auth.yaml"
-        fi
-    fi
-    
-    # Add relay services
-    if [[ "$relay" == "[X]" ]]; then
-        if [[ $IS_GITHUB_DEPLOYMENT -eq 1 ]]; then
-            cmd="$cmd -f docker-compose.dev.relay.yaml"
-        elif [[ $IS_MULTITENANT_DEPLOYMENT -eq 1 ]]; then
-            cmd="$cmd -f docker-compose.multitenant.relay.yaml"
-        else
-            cmd="$cmd -f docker-compose.hub.relay.yaml"
-        fi
-    fi
-    
-    # Add basic logging
-    if [[ "$basiclogs" == "[X]" ]]; then
-        if [[ $IS_GITHUB_DEPLOYMENT -eq 1 ]]; then
-            cmd="$cmd -f docker-compose.dev.logs.base.yaml"
-        else
-            cmd="$cmd -f docker-compose.hub.logs.base.yaml"
-        fi
-    fi
-    
-    # Add utility addons
-    [[ "$ui" == "[X]" ]] && cmd="$cmd -f docker-compose.hub.ui.yaml"
-    [[ "$natsutils" == "[X]" ]] && cmd="$cmd -f docker-compose.utils.nats-utils.yaml"
-    [[ "$batchppa" == "[X]" ]] && cmd="$cmd -f docker-compose.utils.batch-ppa.yaml"
-    [[ "$pgadmin" == "[X]" ]] && cmd="$cmd -f docker-compose.utils.pgadmin.yaml"
-    [[ "$hasura" == "[X]" ]] && cmd="$cmd -f docker-compose.utils.hasura.yaml"
-
-    # Extended addons for GitHub and Public (DockerHub)
-    if is_extended_addons_deployment; then
-        [[ "$cms" == "[X]" ]] && cmd="$cmd -f docker-compose.cms.yaml"
-        [[ "$trs" == "[X]" ]] && cmd="$cmd -f docker-compose.trs.yaml"
-        [[ "$tcs" == "[X]" ]] && cmd="$cmd -f docker-compose.tcs.yaml"
-        [[ "$deapi_dems" == "[X]" ]] && cmd="$cmd -f docker-compose-deapi-dems.yaml"
-        [[ "$opensearch" == "[X]" ]] && cmd="$cmd -f docker-compose.opensearch.yaml"
-    fi
-    
-    echo "$cmd"
-}
-
-# Apply configuration and deploy
-apply_configuration() {
-    if [[ "$tcs" == "[X]" && "$deapi_dems" != "[X]" ]]; then
-        print_color $YELLOW "TCS requires DEAPI & DEMS. Enabling DEAPI & DEMS automatically."
-        deapi_dems="[X]"
-    fi
-
-    if has_opensearch_required_addons_enabled && [[ "$opensearch" != "[X]" ]]; then
-        print_color $YELLOW "CMS/TRS/TCS require OpenSearch. Enabling OpenSearch automatically."
-        opensearch="[X]"
-    fi
-
-    if has_auth_required_addons_enabled && [[ "$auth" != "[X]" ]]; then
-        print_color $YELLOW "Authentication is required for CMS/TRS/TCS/DEAPI&DEMS/OpenSearch. Enabling Authentication automatically."
-        auth="[X]"
-    fi
-
-    local cmd=$(build_docker_command)
-    
-    echo ""
-    print_color $YELLOW "Command to run: $cmd -p tazama up -d"
-    echo ""
-    read -p "Press (e) to execute, (q) to quit or any other key to go back: " confirm
-    echo ""
-    
-    if [[ "$confirm" == "e" || "$confirm" == "E" ]]; then
-        print_color $GREEN "Stopping existing Tazama containers..."
-        echo ""
-        docker compose -p tazama down --volumes --remove-orphans
-        echo ""
-        print_color $GREEN "Deploying Tazama..."
-        echo ""
-        $cmd -p tazama up -d --remove-orphans --force-recreate
-        
-        echo ""
-        print_color $GREEN "✓ Deployment complete!"
-        echo ""
-        read -p "Press Enter to continue..."
-        return 0
-    elif [[ "$confirm" == "q" || "$confirm" == "Q" ]]; then
-        return 0
-    else
+        pause
         return 1
     fi
-}
 
-# Docker utilities menu
-show_utils_menu() {
-    clear
-    echo ""
-    print_color $BLUE "Execute some Docker commands:"
-    echo ""
-    echo "1. Stop and restart ED, TP and EA (reload network configuration)"
-    echo "2. Stop and remove Tazama project containers and volumes"
-    echo "3. Remove all unused containers, networks, images and volumes"
-    echo "4. List all images"
-    echo "5. List all containers"
-    echo "6. List all volumes"
-    echo "7. List all networks"
-    echo ""
-    echo "Select function (1-7), (r)eturn or (q)uit"
-}
-
-# Database utilities menu
-show_dbutils_menu() {
-    clear
-    echo ""
-    print_color $BLUE "Database utilities:"
-    echo ""
-    echo "1. List all PostgreSQL databases"
-    echo "2. List all PostgreSQL tables in all databases"
-    echo "3. Reset Hasura metadata"
-    echo "4. Reinitialize Hasura"
-    echo ""
-    echo "Select function (1-4), (r)eturn or (q)uit"
-}
-
-# Consoles menu
-show_consoles_menu() {
-    clear
-    echo ""
-    print_color $BLUE "Access a service web console:"
-    echo ""
-    echo "1. pgAdmin - localhost:15050"
-    echo "2. Hasura - localhost:6100"
-    echo "3. Keycloak - localhost:8080"
-    echo "4. TMS-service Swagger - localhost:5000/documentation"
-    echo "5. Admin-service Swagger - localhost:5100/documentation"
-    echo ""
-    echo "Select function (1-5), (r)eturn or (q)uit"
-}
-
-# Open URL based on OS
-open_url() {
-    local url=$1
-    
-    if command -v xdg-open &> /dev/null; then
-        xdg-open "$url" 2>/dev/null
-    elif command -v open &> /dev/null; then
-        open "$url" 2>/dev/null
+    local apicmd
+    if [[ "$api_build" == "dev" ]]; then
+        apicmd="docker compose -p $CORE_PROJECT -f ./docker-compose.dev.extensions.apis.yaml"
     else
-        echo "Please open: $url"
+        apicmd="docker compose -p $CORE_PROJECT -f ./docker-compose.hub.extensions.apis.yaml"
     fi
+
+    echo ""
+    echo " Running: $apicmd up -d"
+    $apicmd up -d
+
+    echo ""
+    echo " Done."
+    pause
 }
 
-# Main loop
-while true; do
-    show_main_menu
-    read -p "Enter your choice: " type
-    
-    case $type in
-        1)
-            IS_GITHUB_DEPLOYMENT=1
-            IS_FULL_DEPLOYMENT=0
-            IS_MULTITENANT_DEPLOYMENT=0
-            relay="[X]"
-            
-            # Addons loop
-            while true; do
-                show_addons_menu
-                read -p "Enter your choice: " choice
-                
-                case $choice in
-                    a|A)
-                        if apply_configuration; then
-                            break
-                        fi
-                        ;;
-                    r|R)
-                        break
-                        ;;
-                    q|Q)
-                        exit 0
-                        ;;
-                    1)
-                        if has_auth_required_addons_enabled && [[ "$auth" == "[X]" ]]; then
-                            print_color $YELLOW "Authentication is required while CMS/TRS/TCS/DEAPI&DEMS/OpenSearch is enabled."
-                            sleep 1
-                        else
-                            [[ $IS_MULTITENANT_DEPLOYMENT -ne 1 ]] && toggle_addon "auth"
-                        fi
-                        ;;
-                    2)
-                        [[ $IS_MULTITENANT_DEPLOYMENT -ne 1 ]] && toggle_addon "relay"
-                        ;;
-                    3) toggle_addon "basiclogs" ;;
-                    4) 
-                        if [[ $IS_MULTITENANT_DEPLOYMENT -ne 1 ]]; then
-                            if [[ "$ui" == "[ ]" ]] && has_auth_required_addons_enabled; then
-                                print_color $YELLOW "Demo UI cannot be enabled while CMS/TRS/TCS/DEAPI&DEMS/OpenSearch is selected because those require Authentication."
-                                sleep 2
-                                continue
-                            fi
-                            if [[ "$ui" == "[ ]" ]]; then
-                                ui="[X]"
-                                auth="[ ]"
-                                relay="[ ]"
-                                echo ""
-                                print_color $YELLOW "Note: Enabling the Demo UI addon will disable Authentication and Relay services."
-                                print_color $YELLOW "You can re-enable these services again, but the Demo UI will not function correctly."
-                                echo ""
-                                read -p "Press any key to continue..."
-                            else
-                                ui="[ ]"
-                            fi
-                        fi
-                        ;;
-                    5) toggle_addon "natsutils" ;;
-                    6) toggle_addon "batchppa" ;;
-                    7) toggle_addon "pgadmin" ;;
-                    8) toggle_addon "hasura" ;;
-                    9)
-                        toggle_addon "cms"
-                        if [[ "$cms" == "[X]" ]]; then
-                            auth="[X]"
-                            opensearch="[X]"
-                        fi
-                        ;;
-                    10)
-                        toggle_addon "trs"
-                        if [[ "$trs" == "[X]" ]]; then
-                            auth="[X]"
-                            opensearch="[X]"
-                        fi
-                        ;;
-                    11)
-                        if [[ "$tcs" == "[ ]" ]]; then
-                            tcs="[X]"
-                            deapi_dems="[X]"
-                            auth="[X]"
-                            opensearch="[X]"
-                            print_color $YELLOW "TCS requires DEAPI & DEMS, OpenSearch, and Authentication. All were enabled automatically."
-                            sleep 1
-                        else
-                            tcs="[ ]"
-                        fi
-                        ;;
-                    12)
-                        if [[ "$deapi_dems" == "[X]" && "$tcs" == "[X]" ]]; then
-                            print_color $YELLOW "DEAPI & DEMS cannot be disabled while TCS is enabled."
-                            sleep 1
-                        else
-                            toggle_addon "deapi_dems"
-                            [[ "$deapi_dems" == "[X]" ]] && auth="[X]"
-                        fi
-                        ;;
-                    13)
-                        if [[ "$opensearch" == "[X]" ]] && has_opensearch_required_addons_enabled; then
-                            print_color $YELLOW "OpenSearch cannot be disabled while CMS/TRS/TCS is enabled."
-                            sleep 1
-                        else
-                            toggle_addon "opensearch"
-                            [[ "$opensearch" == "[X]" ]] && auth="[X]"
-                        fi
-                        ;;
-                    *)
-                        print_color $RED "Invalid choice."
-                        sleep 1
-                        ;;
-                esac
-            done
-            ;;
-        2)
-            IS_GITHUB_DEPLOYMENT=0
-            IS_FULL_DEPLOYMENT=0
-            IS_MULTITENANT_DEPLOYMENT=0
-            relay="[X]"
-            
-            while true; do
-                show_addons_menu
-                read -p "Enter your choice: " choice
-                
-                case $choice in
-                    a|A)
-                        if apply_configuration; then
-                            break
-                        fi
-                        ;;
-                    r|R) break ;;
-                    q|Q) exit 0 ;;
-                    1)
-                        if has_auth_required_addons_enabled && [[ "$auth" == "[X]" ]]; then
-                            print_color $YELLOW "Authentication is required while CMS/TRS/TCS/DEAPI&DEMS/OpenSearch is enabled."
-                            sleep 1
-                        else
-                            toggle_addon "auth"
-                        fi
-                        ;;
-                    2) toggle_addon "relay" ;;
-                    3) toggle_addon "basiclogs" ;;
-                    4) 
-                        if [[ "$ui" == "[ ]" ]] && has_auth_required_addons_enabled; then
-                            print_color $YELLOW "Demo UI cannot be enabled while CMS/TRS/TCS/DEAPI&DEMS/OpenSearch is selected because those require Authentication."
-                            sleep 2
-                            continue
-                        fi
-                        if [[ "$ui" == "[ ]" ]]; then
-                            ui="[X]"
-                            auth="[ ]"
-                            relay="[ ]"
-                            echo ""
-                            print_color $YELLOW "Note: Enabling the Demo UI addon will disable Authentication and Relay services."
-                            print_color $YELLOW "You can re-enable these services again, but the Demo UI will not function correctly."
-                            echo ""
-                            read -p "Press any key to continue..."
-                        else
-                            ui="[ ]"
-                        fi
-                        ;;
-                    5) toggle_addon "natsutils" ;;
-                    6) toggle_addon "batchppa" ;;
-                    7) toggle_addon "pgadmin" ;;
-                    8) toggle_addon "hasura" ;;
-                    9)
-                        toggle_addon "cms"
-                        if [[ "$cms" == "[X]" ]]; then
-                            auth="[X]"
-                            opensearch="[X]"
-                        fi
-                        ;;
-                    10)
-                        toggle_addon "trs"
-                        if [[ "$trs" == "[X]" ]]; then
-                            auth="[X]"
-                            opensearch="[X]"
-                        fi
-                        ;;
-                    11)
-                        if [[ "$tcs" == "[ ]" ]]; then
-                            tcs="[X]"
-                            deapi_dems="[X]"
-                            auth="[X]"
-                            opensearch="[X]"
-                            print_color $YELLOW "TCS requires DEAPI & DEMS, OpenSearch, and Authentication. All were enabled automatically."
-                            sleep 1
-                        else
-                            tcs="[ ]"
-                        fi
-                        ;;
-                    12)
-                        if [[ "$deapi_dems" == "[X]" && "$tcs" == "[X]" ]]; then
-                            print_color $YELLOW "DEAPI & DEMS cannot be disabled while TCS is enabled."
-                            sleep 1
-                        else
-                            toggle_addon "deapi_dems"
-                            [[ "$deapi_dems" == "[X]" ]] && auth="[X]"
-                        fi
-                        ;;
-                    13)
-                        if [[ "$opensearch" == "[X]" ]] && has_opensearch_required_addons_enabled; then
-                            print_color $YELLOW "OpenSearch cannot be disabled while CMS/TRS/TCS is enabled."
-                            sleep 1
-                        else
-                            toggle_addon "opensearch"
-                            [[ "$opensearch" == "[X]" ]] && auth="[X]"
-                        fi
-                        ;;
-                    *)
-                        print_color $RED "Invalid choice."
-                        sleep 1
-                        ;;
-                esac
-            done
-            ;;
-        3)
-            IS_GITHUB_DEPLOYMENT=0
-            IS_FULL_DEPLOYMENT=1
-            IS_MULTITENANT_DEPLOYMENT=0
-            relay="[X]"
-            
-            while true; do
-                show_addons_menu
-                read -p "Enter your choice: " choice
-                
-                case $choice in
-                    a|A)
-                        if apply_configuration; then
-                            break
-                        fi
-                        ;;
-                    r|R) break ;;
-                    q|Q) exit 0 ;;
-                    1)
-                        if has_auth_required_addons_enabled && [[ "$auth" == "[X]" ]]; then
-                            print_color $YELLOW "Authentication is required while CMS/TRS/TCS/DEAPI&DEMS/OpenSearch is enabled."
-                            sleep 1
-                        else
-                            toggle_addon "auth"
-                        fi
-                        ;;
-                    2) toggle_addon "relay" ;;
-                    3) toggle_addon "basiclogs" ;;
-                    4) 
-                        if [[ "$ui" == "[ ]" ]] && has_auth_required_addons_enabled; then
-                            print_color $YELLOW "Demo UI cannot be enabled while CMS/TRS/TCS/DEAPI&DEMS/OpenSearch is selected because those require Authentication."
-                            sleep 2
-                            continue
-                        fi
-                        if [[ "$ui" == "[ ]" ]]; then
-                            ui="[X]"
-                            auth="[ ]"
-                            relay="[ ]"
-                            echo ""
-                            print_color $YELLOW "Note: Enabling the Demo UI addon will disable Authentication and Relay services."
-                            print_color $YELLOW "You can re-enable these services again, but the Demo UI will not function correctly."
-                            echo ""
-                            read -p "Press any key to continue..."
-                        else
-                            ui="[ ]"
-                        fi
-                        ;;
-                    5) toggle_addon "natsutils" ;;
-                    6) toggle_addon "batchppa" ;;
-                    7) toggle_addon "pgadmin" ;;
-                    8) toggle_addon "hasura" ;;
-                    9|10|11|12|13)
-                        print_color $YELLOW "These addons are currently available only for Public (GitHub) deployment."
-                        sleep 1
-                        ;;
-                    *)
-                        print_color $RED "Invalid choice."
-                        sleep 1
-                        ;;
-                esac
-            done
-            ;;
-        4)
-            IS_GITHUB_DEPLOYMENT=0
-            IS_FULL_DEPLOYMENT=0
-            IS_MULTITENANT_DEPLOYMENT=1
-            auth="[X]"
-            relay="[X]"
-            
-            while true; do
-                show_addons_menu
-                read -p "Enter your choice: " choice
-                
-                case $choice in
-                    a|A)
-                        if apply_configuration; then
-                            break
-                        fi
-                        ;;
-                    r|R) break ;;
-                    q|Q) exit 0 ;;
-                    1|2)
-                        print_color $YELLOW "Auth and Relay are mandatory for multitenant deployment"
-                        sleep 1
-                        ;;
-                    3) toggle_addon "basiclogs" ;;
-                    4)
-                        print_color $YELLOW "Demo UI is not available for multitenant deployment"
-                        sleep 1
-                        ;;
-                    5) toggle_addon "natsutils" ;;
-                    6) toggle_addon "batchppa" ;;
-                    7) toggle_addon "pgadmin" ;;
-                    8) toggle_addon "hasura" ;;
-                    9|10|11|12|13)
-                        print_color $YELLOW "These addons are currently available only for Public (GitHub) deployment."
-                        sleep 1
-                        ;;
-                    *)
-                        print_color $RED "Invalid choice."
-                        sleep 1
-                        ;;
-                esac
-            done
-            ;;
-        5)
-            # Docker utilities
-            while true; do
-                show_utils_menu
-                read -p "Enter your choice: " choice
-                
-                case $choice in
-                    r|R) break ;;
-                    q|Q) exit 0 ;;
-                    1)
-                        print_color $GREEN "Restarting ED, TP and EA..."
-                        docker restart tazama-tp-1 tazama-event-adjudicator-1 tazama-ed-1
-                        ;;
-                    2)
-                        print_color $YELLOW "Stopping and removing Tazama containers and volumes..."
-                        docker compose -p tazama down --volumes
-                        ;;
-                    3)
-                        print_color $YELLOW "Removing all unused Docker resources..."
-                        docker system prune -a -f --volumes
-                        ;;
-                    4)
-                        docker image ls
-                        ;;
-                    5)
-                        docker container ls
-                        ;;
-                    6)
-                        docker volume ls
-                        ;;
-                    7)
-                        docker network ls
-                        ;;
-                    *)
-                        print_color $RED "Invalid choice."
-                        sleep 1
-                        continue
-                        ;;
-                esac
-                
-                echo ""
-                read -p "Press Enter to continue..."
-            done
-            ;;
-        6)
-            # Database utilities
-            while true; do
-                show_dbutils_menu
-                read -p "Enter your choice: " choice
-                
-                case $choice in
-                    r|R) break ;;
-                    q|Q) exit 0 ;;
-                    1)
-                        print_color $GREEN "Listing PostgreSQL databases..."
-                        docker exec -it tazama-postgres-1 psql -U postgres -c "\l"
-                        ;;
-                    2)
-                        print_color $GREEN "Listing PostgreSQL tables..."
-                        for db in event_history raw_history configuration evaluation; do
-                            echo ""
-                            print_color $CYAN "=== $db ==="
-                            docker exec -it tazama-postgres-1 psql -U postgres -d $db -c "\dt" 2>/dev/null || echo "  (database not found)"
-                        done
-                        ;;
-                    3)
-                        echo ""
-                        print_color $YELLOW "WARNING: This will reset all Hasura metadata!"
-                        read -p "Continue? (y/n): " confirm
-                        
-                        if [[ "$confirm" == "y" || "$confirm" == "Y" ]]; then
-                            print_color $GREEN "Stopping Hasura containers..."
-                            docker stop tazama-hasura-1 tazama-hasura-init-1 2>/dev/null || true
-                            
-                            print_color $GREEN "Removing Hasura containers..."
-                            docker rm tazama-hasura-1 tazama-hasura-init-1 2>/dev/null || true
-                            
-                            print_color $GREEN "Dropping Hasura metadata database..."
-                            docker exec tazama-postgres-1 psql -U postgres -c "DROP DATABASE IF EXISTS hasura;"
-                            docker exec tazama-postgres-1 psql -U postgres -c "CREATE DATABASE hasura;"
-                            
-                            print_color $GREEN "✓ Hasura metadata reset complete!"
-                        fi
-                        ;;
-                    4)
-                        print_color $GREEN "Reinitializing Hasura..."
-                        docker restart tazama-hasura-init-1
-                        ;;
-                    *)
-                        print_color $RED "Invalid choice."
-                        sleep 1
-                        continue
-                        ;;
-                esac
-                
-                echo ""
-                read -p "Press Enter to continue..."
-            done
-            ;;
-        7)
-            # Consoles
-            while true; do
-                show_consoles_menu
-                read -p "Enter your choice: " choice
-                
-                case $choice in
-                    r|R) break ;;
-                    q|Q) exit 0 ;;
-                    1)
-                        print_color $GREEN "Opening pgAdmin..."
-                        open_url "http://localhost:15050"
-                        ;;
-                    2)
-                        print_color $GREEN "Opening Hasura..."
-                        open_url "http://localhost:6100"
-                        ;;
-                    3)
-                        print_color $GREEN "Opening Keycloak..."
-                        open_url "http://localhost:8080"
-                        ;;
-                    4)
-                        print_color $GREEN "Opening TMS-service Swagger..."
-                        open_url "http://localhost:5000/documentation"
-                        ;;
-                    5)
-                        print_color $GREEN "Opening Admin-service Swagger..."
-                        open_url "http://localhost:5100/documentation"
-                        ;;
-                    *)
-                        print_color $RED "Invalid choice."
-                        sleep 1
-                        continue
-                        ;;
-                esac
-                
-                echo ""
-                read -p "Press Enter to continue..."
-            done
-            ;;
-        q|Q)
-            print_color $GREEN "Exiting..."
-            exit 0
-            ;;
-        "")
-            continue
-            ;;
-        *)
-            print_color $RED "Invalid choice. Please try again."
-            sleep 1
-            ;;
-    esac
-done
+# ---------------------------------------------------------------
+# Server B extensions stack
+# ---------------------------------------------------------------
+deploy_extensions() {
+    local build_type=$1
+
+    echo ""
+    echo " Optional services:"
+    echo ""
+    local addon
+    read -rp " Include pgAdmin? [y/N]: " addon
+
+    local pgadmin="false"
+    if [[ "$addon" == "y" || "$addon" == "Y" ]]; then
+        pgadmin="true"
+    fi
+
+    # Auto-copy public key for TCS/TRS volume mounts
+    mkdir -p ./auth
+    if [[ ! -f ./auth/test-public-key.pem ]]; then
+        if [[ -f ../core/auth/test-public-key.pem ]]; then
+            cp -f ../core/auth/test-public-key.pem ./auth/test-public-key.pem
+            echo " Copied test-public-key.pem from core."
+        else
+            echo ""
+            echo " ERROR: ../core/auth/test-public-key.pem not found."
+            echo "        Place the public key in ./auth/ and retry."
+            echo ""
+            pause
+            return 1
+        fi
+    fi
+
+    local cmd="docker compose -p $EXTENSIONS_PROJECT"
+    cmd="$cmd -f ./docker-compose.extensions.infrastructure.yaml"
+    if [[ "$build_type" == "dev" ]]; then
+        cmd="$cmd -f ./docker-compose.dev.extensions.yaml"
+    else
+        cmd="$cmd -f ./docker-compose.hub.extensions.yaml"
+    fi
+    if [[ "$pgadmin" == "true" ]]; then
+        cmd="$cmd -f ./docker-compose.utils.pgadmin.yaml"
+    fi
+
+    echo ""
+    echo " Running: $cmd up -d"
+    $cmd up -d
+
+    echo ""
+    echo " Done."
+    pause
+}
+
+# ---------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------
+down_extensions() {
+    docker compose -p "$EXTENSIONS_PROJECT" \
+        -f ./docker-compose.extensions.infrastructure.yaml \
+        -f ./docker-compose.dev.extensions.yaml \
+        -f ./docker-compose.utils.pgadmin.yaml \
+        down --volumes
+
+    echo ""
+    echo " Done."
+    pause
+}
+
+down_apis() {
+    docker compose -p "$CORE_PROJECT" \
+        -f ./docker-compose.dev.extensions.apis.yaml \
+        down --remove-orphans
+
+    echo ""
+    echo " Done."
+    pause
+}
+
+down_all() {
+    docker compose -p "$EXTENSIONS_PROJECT" \
+        -f ./docker-compose.extensions.infrastructure.yaml \
+        -f ./docker-compose.dev.extensions.yaml \
+        -f ./docker-compose.utils.pgadmin.yaml \
+        down --volumes
+    docker compose -p "$CORE_PROJECT" \
+        -f ./docker-compose.dev.extensions.apis.yaml \
+        down --remove-orphans
+
+    echo ""
+    echo " Done."
+    pause
+}
+
+start_pgadmin() {
+    docker compose -p "$EXTENSIONS_PROJECT" \
+        -f ./docker-compose.utils.pgadmin.yaml \
+        up -d
+
+    echo ""
+    echo " Done."
+    pause
+}
+
+utils() {
+    while true; do
+        clear
+        echo ""
+        echo " Utilities:"
+        echo "   1. Tear down extensions stack  (Server B)"
+        echo "   2. Remove DEMS + DEAPI         (Server A)"
+        echo "   3. Tear down all"
+        echo "   4. Start pgAdmin               (Server B)"
+        echo "   b. Back"
+        echo ""
+        read -rp " Select option: " util
+
+        case "$util" in
+            b|B) return ;;
+            1) down_extensions ;;
+            2) down_apis ;;
+            3) down_all ;;
+            4) start_pgadmin ;;
+        esac
+    done
+}
+
+# ---------------------------------------------------------------
+# Main menu
+# ---------------------------------------------------------------
+menu() {
+    while true; do
+        clear
+        echo ""
+        echo "============================================================"
+        echo " Tazama Extensions Launcher"
+        echo "============================================================"
+        echo ""
+        echo " Server A pre-flight  (run on Server A before Server B):"
+        echo "   1. Deploy DEMS + DEAPI  (GitHub builds)"
+        echo "   2. Deploy DEMS + DEAPI  (DockerHub images)"
+        echo ""
+        echo " Server B extensions stack:"
+        echo "   3. Deploy extensions    (GitHub builds)"
+        echo "   4. Deploy extensions    (DockerHub images)"
+        echo ""
+        echo "   5. Utilities / teardown"
+        echo ""
+        read -rp " Select option (1-5), or (q)uit: " choice
+
+        case "$choice" in
+            q|Q) exit 0 ;;
+            1) deploy_apis "dev" ;;
+            2) deploy_apis "hub" ;;
+            3) deploy_extensions "dev" ;;
+            4) deploy_extensions "hub" ;;
+            5) utils ;;
+        esac
+    done
+}
+
+menu


### PR DESCRIPTION
## Summary

Rebuilds the three launcher shell scripts as faithful ports of their current `.bat` counterparts, which had drifted ahead of the shell versions.

## Changes

- `biar/tazama-biar.sh`: implement the real `tazama-core` pre-flight reachability check (probes NATS port `14222` using `SERVER_A_HOST` from `.env`, via `nc` with a `/dev/tcp` fallback), replacing the previous no-op stub that always passed.
- `core/tazama-core.sh`: drop the Demo UI addon (UI now ships in `hub.core`) and the obsolete Batch PPA addon (promoted to a core service), renumber the addon menu to 1-6, switch to the `tazama-core` project and `tazama-core-*` container names, tear down `tazama-biar`/`tazama-extensions`/`tazama-core` on deploy, and point the pgAdmin console at `localhost:5050`.
- `extensions/tazama-extensions.sh`: replace the obsolete addon-style menu with the current Server A (DEMS + DEAPI) / Server B (extensions stack) launcher, including the `tazama-core` running check and auto-copy of `test-public-key.pem` from core.

## Notes

- Shell-only changes; no compose files or application code affected.
- Verified: no BOM, LF line endings, and `bash -n` passes on all three scripts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added connectivity checks before deploying services, with clear host and port error messages.
  * Added guided deployment workflows for core services, extensions, and Server A/Server B environments.
  * Added optional pgAdmin setup and updated access instructions.
  * Added interactive utilities for managing Docker services, databases, consoles, and stack teardown.

* **Improvements**
  * Simplified add-on selection and deployment menus.
  * Improved handling of required authentication and relay components in multitenant deployments.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->